### PR TITLE
Add mila-cpu entry and add job names to allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Set up your access to the mila cluster interactively. Have your username and pas
 * Set up your public key if you don't already have them
 * Copy your public key over to the cluster for passwordless auth
 * Set up a public key on the login node to enable ssh into compute nodes
+* **new**: Add a special SSH config for direct connection to a **compute node** with `ssh mila-cpu`
 
 
 ### mila docs/intranet

--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -252,7 +252,7 @@ class milatools:
         remote = Remote("mila")
         here = Local()
 
-        cnode = _find_allocation(remote)
+        cnode = _find_allocation(remote, job_name="mila-code")
         if persist:
             cnode = cnode.persist()
         data, proc = cnode.ensure_allocation()
@@ -560,7 +560,7 @@ def _standard_server(
         ):
             exit(f"Exit: {program} is not installed.")
 
-        cnode = _find_allocation(remote)
+        cnode = _find_allocation(remote, job_name=f"mila-serve-{program}")
 
         patterns = {
             "node_name": "#### ([A-Za-z0-9_-]+)",
@@ -647,7 +647,7 @@ def _standard_server(
 
 
 @tooled
-def _find_allocation(remote):
+def _find_allocation(remote, job_name="mila-tools"):
     # Node to connect to
     node: Option = default(None)
 
@@ -670,6 +670,7 @@ def _find_allocation(remote):
         return Remote(node_name)
 
     else:
+        alloc = ["-J", job_name, *alloc]
         return SlurmRemote(
             connection=remote.connection,
             alloc=alloc,

--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -54,34 +54,14 @@ def setup_ssh_config(
         UserKnownHostsFile="/dev/null",
         RequestTTY="force",
         ConnectTimeout=600,
+        ServerAliveInterval=120,
+        # NOTE: will not work with --gres prior to Slurm 22.05, because srun --overlap cannot share it
         ProxyCommand=(
-            """ssh mila "salloc """  #  --partition=unkillable --dependency=singleton
-            """--cpus-per-task=2 --mem=16G """
-            '''/usr/bin/env bash -c 'nc \\$SLURM_NODELIST 22'"'''
+            'ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"'
         ),
-        RemoteCommand="srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l",
+        RemoteCommand="/cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu",
     ):
         changed_entries_in_config.append("mila-cpu")
-
-    if _add_ssh_entry(
-        ssh_config,
-        "mila-gpu",
-        User=username,
-        Port=2222,
-        ForwardAgent="yes",
-        StrictHostKeyChecking="no",
-        LogLevel="ERROR",
-        UserKnownHostsFile="/dev/null",
-        RequestTTY="force",
-        ConnectTimeout=600,
-        ProxyCommand=(
-            """ssh mila "salloc """  # --partition=unkillable --dependency=singleton
-            """--cpus-per-task=2 --mem=16G --gres=gpu:1 """
-            '''/usr/bin/env bash -c 'nc \\$SLURM_NODELIST 22'"'''
-        ),
-        RemoteCommand="srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l",
-    ):
-        changed_entries_in_config.append("mila-gpu")
 
     # Check for *.server.mila.quebec in ssh config, to connect to compute nodes
 

--- a/tests/cli/test_init_command/test_fixes_overly_general_entry.txt
+++ b/tests/cli/test_init_command/test_fixes_overly_general_entry.txt
@@ -19,18 +19,6 @@ Host mila-cpu
   UserKnownHostsFile /dev/null
   RequestTTY force
   ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
-
-
-Host mila-gpu
-  User bob
-  Port 2222
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  LogLevel ERROR
-  UserKnownHostsFile /dev/null
-  RequestTTY force
-  ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l
+  ServerAliveInterval 120
+  ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+  RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu

--- a/tests/cli/test_init_command/test_setup_ssh_empty_confirm_changes_.txt
+++ b/tests/cli/test_init_command/test_setup_ssh_empty_confirm_changes_.txt
@@ -17,21 +17,9 @@ Host mila-cpu
   UserKnownHostsFile /dev/null
   RequestTTY force
   ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
-
-
-Host mila-gpu
-  User bob
-  Port 2222
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  LogLevel ERROR
-  UserKnownHostsFile /dev/null
-  RequestTTY force
-  ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l
+  ServerAliveInterval 120
+  ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+  RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu
 
 
 Host *.server.mila.quebec !*login.server.mila.quebec

--- a/tests/cli/test_init_command/test_setup_ssh_has_comment_and_entry_confirm_changes_.txt
+++ b/tests/cli/test_init_command/test_setup_ssh_has_comment_and_entry_confirm_changes_.txt
@@ -22,21 +22,9 @@ Host mila-cpu
   UserKnownHostsFile /dev/null
   RequestTTY force
   ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
-
-
-Host mila-gpu
-  User bob
-  Port 2222
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  LogLevel ERROR
-  UserKnownHostsFile /dev/null
-  RequestTTY force
-  ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l
+  ServerAliveInterval 120
+  ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+  RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu
 
 
 Host *.server.mila.quebec !*login.server.mila.quebec

--- a/tests/cli/test_init_command/test_setup_ssh_has_comment_confirm_changes_.txt
+++ b/tests/cli/test_init_command/test_setup_ssh_has_comment_confirm_changes_.txt
@@ -18,21 +18,9 @@ Host mila-cpu
   UserKnownHostsFile /dev/null
   RequestTTY force
   ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
-
-
-Host mila-gpu
-  User bob
-  Port 2222
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  LogLevel ERROR
-  UserKnownHostsFile /dev/null
-  RequestTTY force
-  ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l
+  ServerAliveInterval 120
+  ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+  RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu
 
 
 Host *.server.mila.quebec !*login.server.mila.quebec

--- a/tests/cli/test_init_command/test_setup_ssh_has_different_indent_confirm_changes_.txt
+++ b/tests/cli/test_init_command/test_setup_ssh_has_different_indent_confirm_changes_.txt
@@ -20,21 +20,9 @@ Host mila-cpu
     UserKnownHostsFile /dev/null
     RequestTTY force
     ConnectTimeout 600
-    ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-    RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
-
-
-Host mila-gpu
-    User bob
-    Port 2222
-    ForwardAgent yes
-    StrictHostKeyChecking no
-    LogLevel ERROR
-    UserKnownHostsFile /dev/null
-    RequestTTY force
-    ConnectTimeout 600
-    ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-    RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l
+    ServerAliveInterval 120
+    ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+    RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu
 
 
 Host *.server.mila.quebec !*login.server.mila.quebec

--- a/tests/cli/test_init_command/test_with_existing_entries__.txt
+++ b/tests/cli/test_init_command/test_with_existing_entries__.txt
@@ -17,21 +17,9 @@ Host mila-cpu
   UserKnownHostsFile /dev/null
   RequestTTY force
   ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
-
-
-Host mila-gpu
-  User bob
-  Port 2222
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  LogLevel ERROR
-  UserKnownHostsFile /dev/null
-  RequestTTY force
-  ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l
+  ServerAliveInterval 120
+  ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+  RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu
 
 
 Host *.server.mila.quebec !*login.server.mila.quebec

--- a/tests/cli/test_init_command/test_with_existing_entries_mila_.txt
+++ b/tests/cli/test_init_command/test_with_existing_entries_mila_.txt
@@ -11,21 +11,9 @@ Host mila-cpu
   UserKnownHostsFile /dev/null
   RequestTTY force
   ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
-
-
-Host mila-gpu
-  User bob
-  Port 2222
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  LogLevel ERROR
-  UserKnownHostsFile /dev/null
-  RequestTTY force
-  ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l
+  ServerAliveInterval 120
+  ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+  RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu
 
 
 Host *.server.mila.quebec !*login.server.mila.quebec

--- a/tests/cli/test_init_command/test_with_existing_entries_mila_computenode_.txt
+++ b/tests/cli/test_init_command/test_with_existing_entries_mila_computenode_.txt
@@ -19,18 +19,6 @@ Host mila-cpu
   UserKnownHostsFile /dev/null
   RequestTTY force
   ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
-
-
-Host mila-gpu
-  User bob
-  Port 2222
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  LogLevel ERROR
-  UserKnownHostsFile /dev/null
-  RequestTTY force
-  ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l
+  ServerAliveInterval 120
+  ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+  RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu

--- a/tests/cli/test_init_command/test_with_existing_entries_mila_cpu_.txt
+++ b/tests/cli/test_init_command/test_with_existing_entries_mila_cpu_.txt
@@ -10,19 +10,6 @@ Host mila
   ServerAliveCountMax 5
 
 
-Host mila-gpu
-  User bob
-  Port 2222
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  LogLevel ERROR
-  UserKnownHostsFile /dev/null
-  RequestTTY force
-  ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l
-
-
 Host *.server.mila.quebec !*login.server.mila.quebec
   HostName %h
   User bob

--- a/tests/cli/test_init_command/test_with_existing_entries_mila_cpu_mila_computenode_.txt
+++ b/tests/cli/test_init_command/test_with_existing_entries_mila_cpu_mila_computenode_.txt
@@ -11,16 +11,3 @@ Host mila
   Port 2222
   ServerAliveInterval 120
   ServerAliveCountMax 5
-
-
-Host mila-gpu
-  User bob
-  Port 2222
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  LogLevel ERROR
-  UserKnownHostsFile /dev/null
-  RequestTTY force
-  ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l

--- a/tests/cli/test_init_command/test_with_existing_entries_mila_gpu_.txt
+++ b/tests/cli/test_init_command/test_with_existing_entries_mila_gpu_.txt
@@ -19,8 +19,9 @@ Host mila-cpu
   UserKnownHostsFile /dev/null
   RequestTTY force
   ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
+  ServerAliveInterval 120
+  ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+  RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu
 
 
 Host *.server.mila.quebec !*login.server.mila.quebec

--- a/tests/cli/test_init_command/test_with_existing_entries_mila_gpu_mila_computenode_.txt
+++ b/tests/cli/test_init_command/test_with_existing_entries_mila_gpu_mila_computenode_.txt
@@ -22,5 +22,6 @@ Host mila-cpu
   UserKnownHostsFile /dev/null
   RequestTTY force
   ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
+  ServerAliveInterval 120
+  ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+  RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu

--- a/tests/cli/test_init_command/test_with_existing_entries_mila_mila_computenode_.txt
+++ b/tests/cli/test_init_command/test_with_existing_entries_mila_mila_computenode_.txt
@@ -14,18 +14,6 @@ Host mila-cpu
   UserKnownHostsFile /dev/null
   RequestTTY force
   ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
-
-
-Host mila-gpu
-  User bob
-  Port 2222
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  LogLevel ERROR
-  UserKnownHostsFile /dev/null
-  RequestTTY force
-  ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l
+  ServerAliveInterval 120
+  ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+  RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu

--- a/tests/cli/test_init_command/test_with_existing_entries_mila_mila_cpu_.txt
+++ b/tests/cli/test_init_command/test_with_existing_entries_mila_mila_cpu_.txt
@@ -5,19 +5,6 @@ Host mila
 Host mila-cpu
   HostName login.server.mila.quebec
 
-Host mila-gpu
-  User bob
-  Port 2222
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  LogLevel ERROR
-  UserKnownHostsFile /dev/null
-  RequestTTY force
-  ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l
-
-
 Host *.server.mila.quebec !*login.server.mila.quebec
   HostName %h
   User bob

--- a/tests/cli/test_init_command/test_with_existing_entries_mila_mila_cpu_mila_computenode_.txt
+++ b/tests/cli/test_init_command/test_with_existing_entries_mila_mila_cpu_mila_computenode_.txt
@@ -7,15 +7,3 @@ Host mila-cpu
 
 Host *.server.mila.quebec !*login.server.mila.quebec
   HostName foooobar.com
-
-Host mila-gpu
-  User bob
-  Port 2222
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  LogLevel ERROR
-  UserKnownHostsFile /dev/null
-  RequestTTY force
-  ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G --gres=gpu:1 /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --gres=gpu:1 --pty /usr/bin/env bash -l

--- a/tests/cli/test_init_command/test_with_existing_entries_mila_mila_gpu_.txt
+++ b/tests/cli/test_init_command/test_with_existing_entries_mila_mila_gpu_.txt
@@ -14,8 +14,9 @@ Host mila-cpu
   UserKnownHostsFile /dev/null
   RequestTTY force
   ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
+  ServerAliveInterval 120
+  ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+  RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu
 
 
 Host *.server.mila.quebec !*login.server.mila.quebec

--- a/tests/cli/test_init_command/test_with_existing_entries_mila_mila_gpu_mila_computenode_.txt
+++ b/tests/cli/test_init_command/test_with_existing_entries_mila_mila_gpu_mila_computenode_.txt
@@ -17,5 +17,6 @@ Host mila-cpu
   UserKnownHostsFile /dev/null
   RequestTTY force
   ConnectTimeout 600
-  ProxyCommand ssh mila "salloc --cpus-per-task=2 --mem=16G /usr/bin/env bash -c 'nc \$SLURM_NODELIST 22'"
-  RemoteCommand srun --cpus-per-task=2 --mem=16G --pty /usr/bin/env bash -l
+  ServerAliveInterval 120
+  ProxyCommand ssh mila "/cvmfs/config.mila.quebec/scripts/milatools/slurm-proxy.sh mila-cpu --mem=8G"
+  RemoteCommand /cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu


### PR DESCRIPTION
* Add a `mila-cpu` entry that enables `ssh mila-cpu` directly to a compute node.
* Deactivate `mila-gpu` until the next Slurm update.
* Make sure that `mila code` and `mila serve` set an informative job name, for metric collection.
