### PR TITLE
Add a welcome message after mila init

### DIFF
--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -214,9 +214,18 @@ class milatools:
         print("    ssh mila")
         print(T.bold("To allocate and connect to a compute node:"))
         print("    ssh mila-cpu")
+        print(T.bold("To open a directory on the cluster with VSCode:"))
+        print("    mila code path/to/code/on/cluster")
+        print(T.bold("Same as above, but allocate 1 GPU, 4 CPUs, 32G of RAM:"))
+        print(
+            "    mila code path/to/code/on/cluster --alloc --gres=gpu:1 --mem=32G -c 4"
+        )
         print()
         print(
-            "Make sure you read the Mila cluster documentation at",
+            "For more information, read the milatools documentation at",
+            T.bold_cyan("https://github.com/mila-iqia/milatools"),
+            "or run `mila --help`.",
+            "Also make sure you read the Mila cluster documentation at",
             T.bold_cyan("https://docs.mila.quebec/"),
             "and join the",
             T.bold_green("#mila-cluster"),

--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -198,6 +198,30 @@ class milatools:
             ):
                 pubkey = pubkeys[0]
                 remote.run(f"cat {pubkey} >> ~/.ssh/authorized_keys")
+            else:
+                exit("You will not be able to SSH to a compute node")
+
+        ###################
+        # Welcome message #
+        ###################
+
+        print(T.bold_cyan("=" * 60))
+        print(
+            T.bold_cyan("Congrats! You are now ready to start working on the cluster!")
+        )
+        print(T.bold_cyan("=" * 60))
+        print(T.bold("To connect to a login node:"))
+        print("    ssh mila")
+        print(T.bold("To allocate and connect to a compute node:"))
+        print("    ssh mila-cpu")
+        print()
+        print(
+            "Make sure you read the Mila cluster documentation at",
+            T.bold_cyan("https://docs.mila.quebec/"),
+            "and join the",
+            T.bold_green("#mila-cluster"),
+            "channel on Slack.",
+        )
 
     def forward():
         """Forward a port on a compute node to your local machine."""


### PR DESCRIPTION
Following a suggestion from @lebrice, this adds a welcome message at the end of `mila init` that invites user to ssh into the cluster and links the documentation and Slack channel.