### PR TITLE
MT-55 Catch and handle Paramiko SSH errors

### DIFF
--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -23,6 +23,7 @@ from .remote import Remote, SlurmRemote
 from .utils import (
     CommandNotFoundError,
     MilatoolsUserError,
+    SSHConnectionError,
     T,
     qualified,
     randname,
@@ -46,7 +47,7 @@ def main():
         print("ERROR:", exc, file=sys.stderr)
     except SSHConnectionError as err:
         # These are errors coming from paramiko's failure to connect to the host
-        print("ERROR:",err, file=sys.stderr)
+        print("ERROR:", f"{err}", file=sys.stderr)
     except Exception:
         print(T.red(traceback.format_exc()), file=sys.stderr)
         options = {

--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -44,6 +44,9 @@ def main():
     except MilatoolsUserError as exc:
         # These are user errors and should not be reported
         print("ERROR:", exc, file=sys.stderr)
+    except SSHConnectionError as err:
+        # These are errors coming from paramiko's failure to connect to the host
+        print("ERROR:",err, file=sys.stderr)
     except Exception:
         print(T.red(traceback.format_exc()), file=sys.stderr)
         options = {

--- a/milatools/cli/remote.py
+++ b/milatools/cli/remote.py
@@ -4,11 +4,12 @@ import tempfile
 import time
 from pathlib import Path
 from queue import Empty, Queue
+import paramiko
 
 import questionary as qn
 from fabric import Connection
 
-from .utils import T, control_file_var, here, shjoin
+from .utils import T, control_file_var, here, shjoin, SSHConnectionError
 
 batch_template = """#!/bin/bash
 #SBATCH --output={output_file}
@@ -84,9 +85,10 @@ class Remote:
                 if keepalive:
                     connection.open()
                     connection.transport.set_keepalive(keepalive)
+        except paramiko.SSHException as err:
+            raise SSHConnectionError(node_hostname=self.hostname, error=err)
         except Exception as err:
-            raise SSHConnectionError
-            print(str(SSHConnectionError))
+            raise err
         self.connection = connection
         self.transforms = transforms
 

--- a/milatools/cli/remote.py
+++ b/milatools/cli/remote.py
@@ -87,8 +87,6 @@ class Remote:
                     connection.transport.set_keepalive(keepalive)
         except paramiko.SSHException as err:
             raise SSHConnectionError(node_hostname=self.hostname, error=err)
-        except Exception as err:
-            raise err
         self.connection = connection
         self.transforms = transforms
 

--- a/milatools/cli/remote.py
+++ b/milatools/cli/remote.py
@@ -4,12 +4,12 @@ import tempfile
 import time
 from pathlib import Path
 from queue import Empty, Queue
-import paramiko
 
+import paramiko
 import questionary as qn
 from fabric import Connection
 
-from .utils import T, control_file_var, here, shjoin, SSHConnectionError
+from .utils import SSHConnectionError, T, control_file_var, here, shjoin
 
 batch_template = """#!/bin/bash
 #SBATCH --output={output_file}

--- a/milatools/cli/remote.py
+++ b/milatools/cli/remote.py
@@ -78,11 +78,15 @@ def get_first_node_name(node_names_out: str) -> str:
 class Remote:
     def __init__(self, hostname, connection=None, transforms=(), keepalive=60):
         self.hostname = hostname
-        if connection is None:
-            connection = Connection(hostname)
-            if keepalive:
-                connection.open()
-                connection.transport.set_keepalive(keepalive)
+        try:
+            if connection is None:
+                connection = Connection(hostname)
+                if keepalive:
+                    connection.open()
+                    connection.transport.set_keepalive(keepalive)
+        except Exception as err:
+            raise SSHConnectionError
+            print(str(SSHConnectionError))
         self.connection = connection
         self.transforms = transforms
 

--- a/milatools/cli/utils.py
+++ b/milatools/cli/utils.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import blessed
+import paramiko
 import questionary as qn
 from invoke.exceptions import UnexpectedExit
 from sshconf import read_ssh_config
@@ -87,11 +88,20 @@ class CommandNotFoundError(MilatoolsUserError):
 
 
 class SSHConnectionError(Exception):
-    def __init__(self, node_hostname):
+    def __init__(self, node_hostname: str, error: paramiko.SSHException):
         super().__init__()
         self.node_hostname = node_hostname
+        self.error = error
+
     def __str__(self):
-        return repr("An error happened while trying to establish a connection with {self.node_hostname}. Check the status of your connection and of the cluster by ssh'ing onto it. Workaround : try to exclude the node with -x [<node>] parameter")
+        return repr(
+            f"An error happened while trying to establish a connection with {self.node_hostname}. "
+            "Check the status of your connection and of the cluster by ssh'ing onto it. "
+            "Workaround : try to exclude the node with -x [<node>] parameter"
+            "\n"
+            f"Exception: {self.error}"
+        )
+
 
 def yn(prompt: str, default: bool = True) -> bool:
     return qn.confirm(prompt, default=default).unsafe_ask()

--- a/milatools/cli/utils.py
+++ b/milatools/cli/utils.py
@@ -87,20 +87,31 @@ class CommandNotFoundError(MilatoolsUserError):
         return message
 
 
-class SSHConnectionError(Exception):
+class SSHConnectionError(paramiko.SSHException):
     def __init__(self, node_hostname: str, error: paramiko.SSHException):
         super().__init__()
         self.node_hostname = node_hostname
         self.error = error
 
     def __str__(self):
-        return repr(
-            f"An error happened while trying to establish a connection with {self.node_hostname}. "
-            "Check the status of your connection and of the cluster by ssh'ing onto it. "
-            "Workaround : try to exclude the node with -x [<node>] parameter"
-            "\n"
-            f"Exception: {self.error}"
+        return (
+            "An error happened while trying to establish a connection with {0}".format(
+                self.node_hostname
+            )
+            + "\n\t"
+            + "-The cluster might be under maintenance"
+            + "\n\t   "
+            + "Check #mila-cluster for updates on the state of the cluster"
+            + "\n\t"
+            + "-Check the status of your connection to the cluster by ssh'ing onto it."
+            + "\n\t"
+            + "-Retry connecting with mila"
+            + "\n\t"
+            + "-Try to exclude the node with -x {0} parameter".format(
+                self.node_hostname
+            )
         )
+        # f"Exception: {self.error}"
 
 
 def yn(prompt: str, default: bool = True) -> bool:

--- a/milatools/cli/utils.py
+++ b/milatools/cli/utils.py
@@ -111,7 +111,6 @@ class SSHConnectionError(paramiko.SSHException):
                 self.node_hostname
             )
         )
-        # f"Exception: {self.error}"
 
 
 def yn(prompt: str, default: bool = True) -> bool:

--- a/milatools/cli/utils.py
+++ b/milatools/cli/utils.py
@@ -86,6 +86,13 @@ class CommandNotFoundError(MilatoolsUserError):
         return message
 
 
+class SSHConnectionError(Exception):
+    def __init__(self, node_hostname):
+        super().__init__()
+        self.node_hostname = node_hostname
+    def __str__(self):
+        return repr("An error happened while trying to establish a connection with {self.node_hostname}. Check the status of your connection and of the cluster by ssh'ing onto it. Workaround : try to exclude the node with -x [<node>] parameter")
+
 def yn(prompt: str, default: bool = True) -> bool:
     return qn.confirm(prompt, default=default).unsafe_ask()
 


### PR DESCRIPTION
Added a custom Exception class SSHConnectionError. Wraps Remote class with try except raise condition. Prints more explicit error message with possible workarounds instead of basic Exception error message which recommends to file a bug.