### PR TITLE
Bugfix: Actually run disk-quota in `mila code`

### DIFF
--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -542,14 +542,7 @@ def code(
     if command is None:
         command = os.environ.get("MILATOOLS_CODE_COMMAND", "code")
 
-        check_disk_quota(remote)
-
-        cnode = _find_allocation(
-            remote, job=job, node=node, alloc=alloc, job_name="mila-code"
-        )
-        if persist:
-            cnode = cnode.persist()
-        data, proc = cnode.ensure_allocation()
+    check_disk_quota(remote)
 
     cnode = _find_allocation(
         remote, job_name="mila-code", job=job, node=node, alloc=alloc


### PR DESCRIPTION
- Fixes an indentation bug introduced by #52 which removed the `disk-quota` step of the `mila code` command.