### PR TITLE
Don't add the ControlMaster entries when running `mila init` on windows

### DIFF
--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -209,6 +209,9 @@ def _add_ssh_entry(
     ssh_config: SSHConfig,
     host: str,
     Host: str | None = None,
+    *,
+    _space_before: bool = True,
+    _space_after: bool = False,
     **entry,
 ) -> None:
     """Interactively add an entry to the ssh config file.

--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import difflib
+import sys
 from logging import getLogger as get_logger
 from pathlib import Path
-import sys
 
 import questionary as qn
 

--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -55,7 +55,6 @@ def setup_ssh_config(
     _add_ssh_entry(
         ssh_config,
         host="mila",
-        Host=None,
         HostName="login.server.mila.quebec",
         User=username,
         PreferredAuthentications="publickey,keyboard-interactive",
@@ -210,9 +209,6 @@ def _add_ssh_entry(
     ssh_config: SSHConfig,
     host: str,
     Host: str | None = None,
-    *,
-    _space_before: bool = True,
-    _space_after: bool = False,
     **entry,
 ) -> None:
     """Interactively add an entry to the ssh config file.


### PR DESCRIPTION
Fixes #66 