### PR TITLE
Setup VsCode settings for remote development during `mila init`

### DIFF
--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -24,13 +24,14 @@ from typing import Any, Sequence
 from urllib.parse import urlencode
 
 import questionary as qn
-from invoke import UnexpectedExit
+from invoke.exceptions import UnexpectedExit
 from typing_extensions import TypedDict
 
 from ..version import version as mversion
 from .init_command import (
     create_ssh_keypair,
     setup_ssh_config,
+    setup_vscode_settings,
     setup_windows_ssh_config_from_wsl,
 )
 from .local import Local
@@ -405,6 +406,7 @@ def init():
 
     setup_passwordless_ssh_access()
     setup_keys_on_login_node()
+    setup_vscode_settings()
     print_welcome_message()
 
 

--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -394,15 +394,21 @@ def init():
     print("Checking ssh config")
 
     ssh_config = setup_ssh_config()
-    # TODO: Move the rest of this command to functions in the init_command module,
-    # so they can more easily be tested.
-
     print("# OK")
 
-    #############################
-    # Step 2: Passwordless auth #
-    #############################
+    # if we're running on WSL, we actually just copy the id_rsa + id_rsa.pub and the
+    # ~/.ssh/config to the Windows ssh directory (taking care to remove the
+    # ControlMaster-related entries) so that the user doesn't need to install Python on
+    # the Windows side.
+    if running_inside_WSL():
+        setup_windows_ssh_config_from_wsl(linux_ssh_config=ssh_config)
 
+    setup_passwordless_ssh_access()
+    setup_keys_on_login_node()
+    print_welcome_message()
+
+
+def setup_passwordless_ssh_access():
     print("Checking passwordless authentication")
 
     here = Local()
@@ -441,10 +447,8 @@ def init():
         else:
             exit("No passwordless login.")
 
-    #####################################
-    # Step 3: Set up keys on login node #
-    #####################################
 
+def setup_keys_on_login_node():
     print("Checking connection to compute nodes")
 
     remote = Remote("mila")
@@ -482,17 +486,8 @@ def init():
         else:
             exit("You will not be able to SSH to a compute node")
 
-    # TODO: IF we're running on WSL, we could probably actually just copy the
-    # id_rsa.pub and the config to the Windows paths (taking care to remove the
-    # ControlMaster-related entries) so that the user doesn't need to install Python on
-    # the Windows side.
-    if running_inside_WSL():
-        setup_windows_ssh_config_from_wsl(linux_ssh_config=ssh_config)
 
-    ###################
-    # Welcome message #
-    ###################
-
+def print_welcome_message():
     print(T.bold_cyan("=" * 60))
     print(T.bold_cyan("Congrats! You are now ready to start working on the cluster!"))
     print(T.bold_cyan("=" * 60))

--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -264,8 +264,8 @@ def _update_vscode_settings_json(new_values: dict[str, Any]) -> None:
     )
 
     if settings_json == settings_before or not ask_to_confirm_changes(
-        before=json.dumps(settings_before, indent="\t"),
-        after=json.dumps(settings_json, indent="\t"),
+        before=json.dumps(settings_before, indent=4),
+        after=json.dumps(settings_json, indent=4),
         path=vscode_settings_json_path,
     ):
         print(f"Didn't change the VsCode settings at {vscode_settings_json_path}")
@@ -277,7 +277,7 @@ def _update_vscode_settings_json(new_values: dict[str, Any]) -> None:
         )
         vscode_settings_json_path.parent.mkdir(parents=True, exist_ok=True)
     with open(vscode_settings_json_path, "w") as f:
-        json.dump(settings_json, f, indent="\t")
+        json.dump(settings_json, f, indent=4)
 
 
 def _setup_ssh_config_file(config_file_path: str | Path) -> Path:

--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -259,24 +259,25 @@ def _update_vscode_settings_json(new_values: dict[str, Any]) -> None:
             settings_json = json.load(f)
 
     settings_before = copy.deepcopy(settings_json)
-    settings_json.update(new_values)
+    settings_json.update(
+        {k: v for k, v in new_values.items() if k not in settings_json}
+    )
 
-    if settings_json != settings_before and ask_to_confirm_changes(
-        before=json.dumps(settings_before, indent=4),
-        after=json.dumps(settings_json, indent=4),
+    if settings_json == settings_before or not ask_to_confirm_changes(
+        before=json.dumps(settings_before, indent="\t"),
+        after=json.dumps(settings_json, indent="\t"),
         path=vscode_settings_json_path,
     ):
-        if not vscode_settings_json_path.exists():
-            logger.info(
-                f"Creating a new VsCode settings file at {vscode_settings_json_path}"
-            )
-            vscode_settings_json_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(vscode_settings_json_path, "w") as f:
-            json.dump(settings_json, f, indent=4)
-    else:
         print(f"Didn't change the VsCode settings at {vscode_settings_json_path}")
+        return
 
-    # No change, don't write the file.
+    if not vscode_settings_json_path.exists():
+        logger.info(
+            f"Creating a new VsCode settings file at {vscode_settings_json_path}"
+        )
+        vscode_settings_json_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(vscode_settings_json_path, "w") as f:
+        json.dump(settings_json, f, indent="\t")
 
 
 def _setup_ssh_config_file(config_file_path: str | Path) -> Path:

--- a/milatools/cli/utils.py
+++ b/milatools/cli/utils.py
@@ -143,7 +143,7 @@ class SSHConfig:
     """Wrapper around sshconf with some extra niceties."""
 
     def __init__(self, path: str | Path):
-        self.path = path
+        self.path = Path(path)
         self.cfg = read_ssh_config(path)
         # self.add = self.cfg.add
         self.remove = self.cfg.remove

--- a/milatools/cli/vscode_utils.py
+++ b/milatools/cli/vscode_utils.py
@@ -1,0 +1,37 @@
+import shutil
+import subprocess
+import sys
+from logging import getLogger as get_logger
+from pathlib import Path
+
+logger = get_logger(__name__)
+
+
+def running_inside_WSL() -> bool:
+    return sys.platform == "linux" and bool(shutil.which("powershell.exe"))
+
+
+def get_expected_vscode_settings_json_path() -> Path:
+    if sys.platform == "win32":
+        return Path.home() / "AppData\\Roaming\\Code\\User\\settings.json"
+    if sys.platform == "darwin":  # MacOS
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Code"
+            / "User"
+            / "settings.json"
+        )
+    if running_inside_WSL():
+        # Need to get the Windows Home directory, not the WSL one!
+        windows_username = subprocess.getoutput("powershell.exe '$env:UserName'")
+        return Path(
+            f"/mnt/c/Users/{windows_username}/AppData/Roaming/Code/User/settings.json"
+        )
+    # Linux:
+    return Path.home() / ".config/Code/User/settings.json"
+
+
+def vscode_installed() -> bool:
+    return bool(shutil.which("code"))

--- a/milatools/cli/vscode_utils.py
+++ b/milatools/cli/vscode_utils.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 import sys
@@ -34,4 +35,4 @@ def get_expected_vscode_settings_json_path() -> Path:
 
 
 def vscode_installed() -> bool:
-    return bool(shutil.which("code"))
+    return bool(shutil.which(os.environ.get("MILATOOLS_CODE_COMMAND", "code")))

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -639,7 +639,7 @@ def test_setup_vscode_settings(
     vscode_settings_json_path = tmp_path / "settings.json"
     if initial_settings is not None:
         with open(vscode_settings_json_path, "w") as f:
-            json.dump(initial_settings, f, indent="\t")
+            json.dump(initial_settings, f, indent=4)
 
     monkeypatch.setattr(
         init_command,
@@ -693,7 +693,7 @@ def test_setup_vscode_settings(
                         "this initial content:",
                         "",
                         "```json",
-                        json.dumps(initial_settings, indent="\t"),
+                        json.dumps(initial_settings, indent=4),
                         "```",
                     ]
                 )

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -639,7 +639,7 @@ def test_setup_vscode_settings(
     vscode_settings_json_path = tmp_path / "settings.json"
     if initial_settings is not None:
         with open(vscode_settings_json_path, "w") as f:
-            json.dump(initial_settings, f)
+            json.dump(initial_settings, f, indent="\t")
 
     monkeypatch.setattr(
         init_command,
@@ -660,6 +660,7 @@ def test_setup_vscode_settings(
         input_pipe.send_text(user_input)
 
     setup_vscode_settings()
+
     resulting_contents: str | None = None
     resulting_settings: dict | None = None
 

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -12,7 +12,6 @@ import pytest
 import questionary
 from prompt_toolkit.input import PipeInput, create_pipe_input
 from pytest_regressions.file_regression import FileRegressionFixture
-from milatools.cli import init_command
 
 from milatools.cli import init_command
 from milatools.cli.init_command import (

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -693,7 +693,7 @@ def test_setup_vscode_settings(
                         "this initial content:",
                         "",
                         "```json",
-                        json.dumps(initial_settings, indent=4),
+                        json.dumps(initial_settings, indent="\t"),
                         "```",
                     ]
                 )

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -624,7 +624,9 @@ def test_setup_windows_ssh_config_from_wsl(
     file_regression.check(expected_text, extension=".md")
 
 
-@pytest.mark.parametrize("initial_settings", [None, {}, {"foo": "bar"}])
+@pytest.mark.parametrize(
+    "initial_settings", [None, {}, {"foo": "bar"}, {"remote.SSH.connectTimeout": 123}]
+)
 @pytest.mark.parametrize("accept_changes", [True, False], ids=["accept", "reject"])
 def test_setup_vscode_settings(
     tmp_path: Path,

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -20,8 +20,8 @@ from milatools.cli.init_command import (
     create_ssh_keypair,
     get_windows_home_path_in_wsl,
     setup_ssh_config,
-    setup_windows_ssh_config_from_wsl,
     setup_vscode_settings,
+    setup_windows_ssh_config_from_wsl,
 )
 from milatools.cli.local import Local
 from milatools.cli.utils import SSHConfig, running_inside_WSL

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import subprocess
 import textwrap
 from functools import partial
@@ -11,6 +12,7 @@ import pytest
 import questionary
 from prompt_toolkit.input import PipeInput, create_pipe_input
 from pytest_regressions.file_regression import FileRegressionFixture
+from milatools.cli import init_command
 
 from milatools.cli import init_command
 from milatools.cli.init_command import (
@@ -20,6 +22,7 @@ from milatools.cli.init_command import (
     get_windows_home_path_in_wsl,
     setup_ssh_config,
     setup_windows_ssh_config_from_wsl,
+    setup_vscode_settings,
 )
 from milatools.cli.local import Local
 from milatools.cli.utils import SSHConfig, running_inside_WSL
@@ -614,6 +617,92 @@ def test_setup_windows_ssh_config_from_wsl(
             "",
             "```",
             windows_ssh_config_path.read_text(),
+            "```",
+        ]
+    )
+
+    file_regression.check(expected_text, extension=".md")
+
+
+@pytest.mark.parametrize("initial_settings", [None, {}, {"foo": "bar"}])
+@pytest.mark.parametrize("accept_changes", [True, False], ids=["accept", "reject"])
+def test_setup_vscode_settings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    input_pipe: PipeInput,
+    initial_settings: dict | None,
+    file_regression: FileRegressionFixture,
+    accept_changes: bool,
+):
+    vscode_settings_json_path = tmp_path / "settings.json"
+    if initial_settings is not None:
+        with open(vscode_settings_json_path, "w") as f:
+            json.dump(initial_settings, f)
+
+    monkeypatch.setattr(
+        init_command,
+        init_command.vscode_installed.__name__,
+        Mock(spec=init_command.vscode_installed, return_value=True),
+    )
+    monkeypatch.setattr(
+        init_command,
+        init_command.get_expected_vscode_settings_json_path.__name__,
+        Mock(
+            spec=init_command.get_expected_vscode_settings_json_path,
+            return_value=vscode_settings_json_path,
+        ),
+    )
+
+    user_inputs = ["y" if accept_changes else "n"]
+    for user_input in user_inputs:
+        input_pipe.send_text(user_input)
+
+    setup_vscode_settings()
+    resulting_contents: str | None = None
+    resulting_settings: dict | None = None
+
+    if not accept_changes and initial_settings is None:
+        # Shouldn't create the file if we don't accept the changes and there's no
+        # initial file.
+        assert not vscode_settings_json_path.exists()
+
+    if vscode_settings_json_path.exists():
+        resulting_contents = vscode_settings_json_path.read_text()
+        resulting_settings = json.loads(resulting_contents)
+        assert isinstance(resulting_settings, dict)
+
+    if not accept_changes:
+        if initial_settings is None:
+            assert not vscode_settings_json_path.exists()
+            return  # skip creating the regression file in that case.
+        assert resulting_settings == initial_settings
+        return
+
+    assert resulting_contents is not None
+    assert resulting_settings is not None
+
+    expected_text = "\n".join(
+        [
+            f"Calling `{setup_vscode_settings.__name__}()` with "
+            + (
+                "\n".join(
+                    [
+                        "this initial content:",
+                        "",
+                        "```json",
+                        json.dumps(initial_settings, indent=4),
+                        "```",
+                    ]
+                )
+                if initial_settings is not None
+                else "no initial VsCode settings file"
+            ),
+            "",
+            f"and these user inputs: {tuple(user_inputs)}",
+            "leads the following VsCode settings file:",
+            "",
+            "```json",
+            resulting_contents,
             "```",
         ]
     )

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_None_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_None_.md
@@ -1,0 +1,10 @@
+Calling `setup_vscode_settings()` with no initial VsCode settings file
+
+and these user inputs: ('y',)
+leads the following VsCode settings file:
+
+```json
+{
+    "remote.SSH.connectTimeout": 60
+}
+```

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_None_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_None_.md
@@ -5,6 +5,6 @@ leads the following VsCode settings file:
 
 ```json
 {
-	"remote.SSH.connectTimeout": 60
+    "remote.SSH.connectTimeout": 60
 }
 ```

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_None_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_None_.md
@@ -5,6 +5,6 @@ leads the following VsCode settings file:
 
 ```json
 {
-    "remote.SSH.connectTimeout": 60
+	"remote.SSH.connectTimeout": 60
 }
 ```

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings1_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings1_.md
@@ -1,0 +1,14 @@
+Calling `setup_vscode_settings()` with this initial content:
+
+```json
+{}
+```
+
+and these user inputs: ('y',)
+leads the following VsCode settings file:
+
+```json
+{
+    "remote.SSH.connectTimeout": 60
+}
+```

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings1_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings1_.md
@@ -9,6 +9,6 @@ leads the following VsCode settings file:
 
 ```json
 {
-	"remote.SSH.connectTimeout": 60
+    "remote.SSH.connectTimeout": 60
 }
 ```

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings1_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings1_.md
@@ -9,6 +9,6 @@ leads the following VsCode settings file:
 
 ```json
 {
-    "remote.SSH.connectTimeout": 60
+	"remote.SSH.connectTimeout": 60
 }
 ```

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings2_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings2_.md
@@ -2,7 +2,7 @@ Calling `setup_vscode_settings()` with this initial content:
 
 ```json
 {
-    "foo": "bar"
+	"foo": "bar"
 }
 ```
 

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings2_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings2_.md
@@ -2,7 +2,7 @@ Calling `setup_vscode_settings()` with this initial content:
 
 ```json
 {
-	"foo": "bar"
+    "foo": "bar"
 }
 ```
 
@@ -11,7 +11,7 @@ leads the following VsCode settings file:
 
 ```json
 {
-	"foo": "bar",
-	"remote.SSH.connectTimeout": 60
+    "foo": "bar",
+    "remote.SSH.connectTimeout": 60
 }
 ```

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings2_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings2_.md
@@ -1,0 +1,17 @@
+Calling `setup_vscode_settings()` with this initial content:
+
+```json
+{
+    "foo": "bar"
+}
+```
+
+and these user inputs: ('y',)
+leads the following VsCode settings file:
+
+```json
+{
+    "foo": "bar",
+    "remote.SSH.connectTimeout": 60
+}
+```

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings2_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings2_.md
@@ -11,7 +11,7 @@ leads the following VsCode settings file:
 
 ```json
 {
-    "foo": "bar",
-    "remote.SSH.connectTimeout": 60
+	"foo": "bar",
+	"remote.SSH.connectTimeout": 60
 }
 ```

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings3_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings3_.md
@@ -2,7 +2,7 @@ Calling `setup_vscode_settings()` with this initial content:
 
 ```json
 {
-	"remote.SSH.connectTimeout": 123
+    "remote.SSH.connectTimeout": 123
 }
 ```
 
@@ -11,6 +11,6 @@ leads the following VsCode settings file:
 
 ```json
 {
-	"remote.SSH.connectTimeout": 123
+    "remote.SSH.connectTimeout": 123
 }
 ```

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings3_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings3_.md
@@ -11,6 +11,6 @@ leads the following VsCode settings file:
 
 ```json
 {
-    "remote.SSH.connectTimeout": 60
+	"remote.SSH.connectTimeout": 123
 }
 ```

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings3_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings3_.md
@@ -1,0 +1,16 @@
+Calling `setup_vscode_settings()` with this initial content:
+
+```json
+{
+    "remote.SSH.connectTimeout": 123
+}
+```
+
+and these user inputs: ('y',)
+leads the following VsCode settings file:
+
+```json
+{
+    "remote.SSH.connectTimeout": 60
+}
+```

--- a/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings3_.md
+++ b/tests/cli/test_init_command/test_setup_vscode_settings_accept_initial_settings3_.md
@@ -2,7 +2,7 @@ Calling `setup_vscode_settings()` with this initial content:
 
 ```json
 {
-    "remote.SSH.connectTimeout": 123
+	"remote.SSH.connectTimeout": 123
 }
 ```
 

--- a/tests/cli/test_vscode_utils.py
+++ b/tests/cli/test_vscode_utils.py
@@ -1,0 +1,41 @@
+import shutil
+
+import pytest
+
+from milatools.cli.vscode_utils import (
+    get_expected_vscode_settings_json_path,
+    vscode_installed,
+)
+
+
+def test_vscode_installed(monkeypatch: pytest.MonkeyPatch):
+    """Check that on a dev machine with VsCode installed, this function returns True."""
+    monkeypatch.setenv("PATH", "")
+    assert not vscode_installed()
+
+
+@pytest.mark.parametrize("custom_code_command", ["ls", "fake-code-doesnt-exist"])
+def test_vscode_installed_with_env_var(
+    custom_code_command: str, monkeypatch: pytest.MonkeyPatch
+):
+    """Check the fn returns whether the custom vscode command is available when set."""
+    monkeypatch.setenv("MILATOOLS_CODE_COMMAND", custom_code_command)
+    assert vscode_installed() == bool(shutil.which(custom_code_command))
+
+
+@pytest.mark.xfail(
+    not vscode_installed(),
+    reason="This machine doesn't have VsCode installed.",
+    strict=True,
+)
+def test_get_expected_vscode_settings_json_path():
+    """Check that on a dev machine with VsCode the expected path points to a real
+    file."""
+    expected_path = get_expected_vscode_settings_json_path()
+    print(expected_path)
+    assert expected_path.exists()
+    # NOTE: Seems like there can sometimes be some issues reading some of these setting
+    # files. Leaving this commented for now.
+    # with open(expected_path, "r") as f:
+    #     settings_dict = json.load(f)
+    # assert isinstance(settings_dict, dict)


### PR DESCRIPTION
- `mila init` now tries to update the User settings of VsCode with a  `"remote.SSH.connectTimeout": 60`


Are there other useful entries we should add?
Anything particular to Windows/Mac/Linux?

Let us know! :)


TODOs: 
- [x] Add a test for this using a mock path for the VsCode settings json file.
