### PR TITLE
Fix running tests that use SSH in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,22 @@ jobs:
       if: ${{ matrix.python-version == '3.10' }}
       run: poetry run isort -c --df .
 
+    - name: Setup passwordless SSH access to localhost for tests
+      # Adapted from https://stackoverflow.com/a/60367309/6388696
+      run: |
+        ssh-keygen -t ed25519 -f ~/.ssh/whatever -N ''
+        cat > ~/.ssh/config <<EOF
+          Host localhost
+           User $USER
+           HostName 127.0.0.1
+           IdentityFile ~/.ssh/whatever
+        EOF
+        echo -n 'from="127.0.0.1" ' | cat - ~/.ssh/whatever.pub > ~/.ssh/authorized_keys
+        echo "Before fixing permissions on authorized_keys, notice home directory is world read/write"
+        ls -la ~/.ssh
+        chmod og-rw ~
+        ssh -o 'StrictHostKeyChecking no' localhost id
+
     - name: Test with pytest
       run: poetry run pytest
 

--- a/tests/cli/common.py
+++ b/tests/cli/common.py
@@ -16,13 +16,13 @@ if typing.TYPE_CHECKING:
 
 P = ParamSpec("P")
 
-
+REQUIRES_S_FLAG_REASON = (
+    "Seems to require reading from stdin? Works with the -s flag, but other "
+    "tests might not."
+)
 requires_s_flag = pytest.mark.skipif(
     "-s" not in sys.argv,
-    reason=(
-        "Seems to require reading from stdin? Works with the -s flag, but other "
-        "tests might not."
-    ),
+    reason=REQUIRES_S_FLAG_REASON,
 )
 
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+from .common import REQUIRES_S_FLAG_REASON
+
+
+@pytest.fixture(autouse=True)
+def skip_if_s_flag_passed_and_test_doesnt_require_it(
+    request: pytest.FixtureRequest, pytestconfig: pytest.Config
+):
+    capture_value = pytestconfig.getoption("-s")
+    assert capture_value in ["no", "fd"]
+    s_flag_set = capture_value == "no"
+    test_requires_s_flag = any(
+        mark.name == "skipif"
+        and mark.kwargs.get("reason", "") == REQUIRES_S_FLAG_REASON
+        for mark in request.node.iter_markers()
+    )
+    if s_flag_set and not test_requires_s_flag:
+        # NOTE: WE only run the tests that require -s when -s is passed, because
+        # otherwise we get very weird errors related to closed file descriptors!
+        pytest.skip(reason="Running with the -s flag and this test doesn't require it.")


### PR DESCRIPTION
- add a build step in the GitHub actions CI to setup passwordless ssh to `localhost` for the rest of the tests.
- Only run tests that require the `-s` flag to run when running tests with the `-s` flag.
    - This alleviates the "Operation on closed file" issue that happens for example here: https://github.com/mila-iqia/milatools/actions/runs/7009695285/job/19068696634?pr=77