### PR TITLE
Fix a bug in `mila init` (see desc.)

### DIFF
--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -105,7 +105,7 @@ def setup_ssh_config(
             'mila-cpu --mem=8G"'
         ),
         RemoteCommand=(
-            "/cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu",
+            "/cvmfs/config.mila.quebec/scripts/milatools/entrypoint.sh mila-cpu"
         ),
     )
 


### PR DESCRIPTION
- Fixes #82

Weird that this bug got through the CI, honestly!
Once we add code-coverage we might get a better idea how this happened. Essentially, there was an extra "," in a string inside parentheses, which made this into a tuple instead of a string.