### PR TITLE
Add publish GitHub Action workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9]
-        poetry-version: [1.1.2]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+# This workflow will upload a Python Package using Poetry when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    strategy:
+      matrix:
+        python-version: [3.9]
+        poetry-version: [1.1.2]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install poetry
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: poetry
+
+    - name: Install dependencies
+      run: poetry install --with=dev
+
+    - name: Publish package
+      run: poetry publish --build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
         cache: poetry
 
     - name: Install dependencies
-      run: poetry install --with=dev
+      run: poetry install
 
     - name: Publish package
       run: poetry publish --build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,5 +35,5 @@ jobs:
 
     - name: Publish package
       env:
-        POETRY_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
       run: poetry publish --build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
         python-version: [3.9]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    environment: release
     steps:
     - uses: actions/checkout@v4
     - name: Install poetry
@@ -33,4 +34,6 @@ jobs:
       run: poetry install
 
     - name: Publish package
+      env:
+        POETRY_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       run: poetry publish --build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "milatools"
-version = "0.0.18"
+version = "0.0.0"
 description = "Tools to work with the Mila cluster"
 authors = ["Olivier Breuleux <breuleux@gmail.com>"]
 readme = "README.md"
@@ -48,6 +48,10 @@ combine_as_imports = true
 addopts = "--doctest-modules"
 markers = "--enable-internet: Allow some tests to run using real connections to the cluster."
 
+
+[tool.poetry-dynamic-versioning]
+enable = true
+
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
- Adds a new "Publish package" GitHub Action that gets triggered when a new release is created on GitHub.
- Also uses the poetry_dynamic_versioning plugin to set the version based on the tag, similar to what versioneer would do with a setup.py.