### PR TITLE
Fix dynamic versioning not working in the CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,9 @@ jobs:
         cache: poetry
 
     - name: Install dependencies
-      run: poetry install
+      run: |
+        poetry install
+        poetry self add "poetry-dynamic-versioning[plugin]"
 
     - name: Publish package
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ markers = "--enable-internet: Allow some tests to run using real connections to 
 
 [tool.poetry-dynamic-versioning]
 enable = true
+vcs = "git"
+style = "semver"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]


### PR DESCRIPTION
During the recent release, the package version was 0.0.0 in the GitHub CI: 
https://github.com/mila-iqia/milatools/actions/runs/7572023233/job/20621010227#step:6:36


This is the same issue as in https://github.com/mtkennerly/poetry-dynamic-versioning/issues/145

I made the release myself with `poetry publish --build` on my local machine, although in retrospect I probably shouldn't have done that.

This PR is an attempt to fix the issue with the dynamic versioning in the GitHub CI so that the publishing it actually taken care of by GitHub Actions for the next release. I'm trying to do this by adapting the solution proposed in https://github.com/mtkennerly/poetry-dynamic-versioning/issues/145#issuecomment-1719645691 by installing the dynamic versioning plugin explicitly in the CI. 

I find it surprising that doing `poetry install` wouldn't also install the poetry plugins though :thinking:  