### PR TITLE
Drop support for python 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       max-parallel: 4
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     env:
       PLATFORM: ${{ matrix.platform }}
     steps:
@@ -82,7 +82,7 @@ jobs:
         # TODO: We should ideally also run this with Windows/Mac clients and a Linux
         # server. Unsure how to set that up with GitHub Actions though.
         platform: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     # For the action to work, you have to supply a mysql
     # service as defined below.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,25 +36,15 @@ repos:
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.0.261"
+    rev: v0.1.14
     hooks:
+      # Run the linter.
       - id: ruff
-        args: ["--line-length", "88", "--fix"]
+        args: ['--line-length', '88', "--select", "I,UP", '--fix']
         require_serial: true
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
-
-  # python code formatting
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
-    hooks:
-      - id: black
-        args: [--line-length, "88"]
-        require_serial: true
+      # Run the formatter.
+      - id: ruff-format
+        args: ['--line-length', '88']
 
   # python docstring formatting
   - repo: https://github.com/myint/docformatter

--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -18,10 +18,11 @@ import typing
 import warnings
 import webbrowser
 from argparse import ArgumentParser, _HelpAction
+from collections.abc import Sequence
 from contextlib import ExitStack
 from logging import getLogger as get_logger
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any
 from urllib.parse import urlencode
 
 import questionary as qn
@@ -1073,9 +1074,7 @@ def _get_disk_quota_usage(
         _quota2,
         limit_files,
         _grace2,
-    ) = (
-        lines[2].strip().split()
-    )
+    ) = lines[2].strip().split()
 
     used_gb = float(int(used_kbytes.strip()) / (1024) ** 2)
     max_gb = float(int(limit_kbytes.strip()) / (1024) ** 2)

--- a/milatools/cli/local.py
+++ b/milatools/cli/local.py
@@ -42,7 +42,7 @@ class Local:
                 stdout=stdout,
                 stderr=stderr,
                 capture_output=capture_output,
-                universal_newlines=True,
+                text=True,
                 timeout=timeout,
                 check=check,
             )

--- a/milatools/cli/profile.py
+++ b/milatools/cli/profile.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import json
 import re
 import typing
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Generic, Sequence, TypeVar
+from typing import Generic, TypeVar
 
 import invoke
 import questionary as qn

--- a/milatools/cli/remote.py
+++ b/milatools/cli/remote.py
@@ -4,9 +4,10 @@ import re
 import socket
 import tempfile
 import time
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 from queue import Empty, Queue
-from typing import Callable, Iterable, Sequence, TextIO, overload
+from typing import Literal, TextIO, overload
 
 import fabric
 import fabric.transfer
@@ -14,7 +15,7 @@ import invoke
 import paramiko
 import questionary as qn
 from fabric import Connection
-from typing_extensions import Literal, Self, TypedDict, deprecated
+from typing_extensions import Self, TypedDict, deprecated
 
 from .utils import SSHConnectionError, T, control_file_var, here, shjoin
 

--- a/milatools/cli/utils.py
+++ b/milatools/cli/utils.py
@@ -12,16 +12,17 @@ import subprocess
 import sys
 import typing
 import warnings
+from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, Iterable, Union
+from typing import Any, Literal, TypeGuard, Union, get_args
 
 import blessed
 import paramiko
 import questionary as qn
 from invoke.exceptions import UnexpectedExit
 from sshconf import ConfigLine, SshConfigFile, read_ssh_config
-from typing_extensions import Literal, ParamSpec, TypeGuard, get_args
+from typing_extensions import ParamSpec
 
 if typing.TYPE_CHECKING:
     from milatools.cli.remote import Remote
@@ -275,7 +276,7 @@ def get_fully_qualified_name() -> str:
         return socket.getfqdn()
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def running_inside_WSL() -> bool:
     return sys.platform == "linux" and bool(shutil.which("powershell.exe"))
 

--- a/milatools/cli/utils.py
+++ b/milatools/cli/utils.py
@@ -15,14 +15,14 @@ import warnings
 from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Literal, TypeGuard, Union, get_args
+from typing import Any, Literal, Union, get_args
 
 import blessed
 import paramiko
 import questionary as qn
 from invoke.exceptions import UnexpectedExit
 from sshconf import ConfigLine, SshConfigFile, read_ssh_config
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, TypeGuard
 
 if typing.TYPE_CHECKING:
     from milatools.cli.remote import Remote

--- a/milatools/cli/vscode_utils.py
+++ b/milatools/cli/vscode_utils.py
@@ -5,9 +5,9 @@ import shutil
 import subprocess
 import sys
 import tarfile
+from collections.abc import Iterable
 from logging import getLogger as get_logger
 from pathlib import Path
-from typing import Iterable
 
 import tqdm
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -120,7 +120,6 @@ packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
@@ -344,7 +343,6 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -592,7 +590,6 @@ files = [
 ]
 
 [package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
@@ -815,9 +812,6 @@ files = [
     {file = "platformdirs-4.0.0.tar.gz", hash = "sha256:cb633b2bcf10c51af60beb0ab06d2f1d69064b43abf4c185ca6b28865f3f9731"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.7.1", markers = "python_version < \"3.8\""}
-
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
@@ -832,9 +826,6 @@ files = [
     {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
     {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
 ]
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -942,7 +933,6 @@ files = [
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -1394,56 +1384,6 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
-name = "typed-ast"
-version = "1.5.5"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "typed_ast-1.5.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4bc1efe0ce3ffb74784e06460f01a223ac1f6ab31c6bc0376a21184bf5aabe3b"},
-    {file = "typed_ast-1.5.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5f7a8c46a8b333f71abd61d7ab9255440d4a588f34a21f126bbfc95f6049e686"},
-    {file = "typed_ast-1.5.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:597fc66b4162f959ee6a96b978c0435bd63791e31e4f410622d19f1686d5e769"},
-    {file = "typed_ast-1.5.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d41b7a686ce653e06c2609075d397ebd5b969d821b9797d029fccd71fdec8e04"},
-    {file = "typed_ast-1.5.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5fe83a9a44c4ce67c796a1b466c270c1272e176603d5e06f6afbc101a572859d"},
-    {file = "typed_ast-1.5.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d5c0c112a74c0e5db2c75882a0adf3133adedcdbfd8cf7c9d6ed77365ab90a1d"},
-    {file = "typed_ast-1.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:e1a976ed4cc2d71bb073e1b2a250892a6e968ff02aa14c1f40eba4f365ffec02"},
-    {file = "typed_ast-1.5.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c631da9710271cb67b08bd3f3813b7af7f4c69c319b75475436fcab8c3d21bee"},
-    {file = "typed_ast-1.5.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b445c2abfecab89a932b20bd8261488d574591173d07827c1eda32c457358b18"},
-    {file = "typed_ast-1.5.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc95ffaaab2be3b25eb938779e43f513e0e538a84dd14a5d844b8f2932593d88"},
-    {file = "typed_ast-1.5.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61443214d9b4c660dcf4b5307f15c12cb30bdfe9588ce6158f4a005baeb167b2"},
-    {file = "typed_ast-1.5.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6eb936d107e4d474940469e8ec5b380c9b329b5f08b78282d46baeebd3692dc9"},
-    {file = "typed_ast-1.5.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e48bf27022897577d8479eaed64701ecaf0467182448bd95759883300ca818c8"},
-    {file = "typed_ast-1.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:83509f9324011c9a39faaef0922c6f720f9623afe3fe220b6d0b15638247206b"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:44f214394fc1af23ca6d4e9e744804d890045d1643dd7e8229951e0ef39429b5"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:118c1ce46ce58fda78503eae14b7664163aa735b620b64b5b725453696f2a35c"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4919b808efa61101456e87f2d4c75b228f4e52618621c77f1ddcaae15904fa"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:fc2b8c4e1bc5cd96c1a823a885e6b158f8451cf6f5530e1829390b4d27d0807f"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:16f7313e0a08c7de57f2998c85e2a69a642e97cb32f87eb65fbfe88381a5e44d"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:2b946ef8c04f77230489f75b4b5a4a6f24c078be4aed241cfabe9cbf4156e7e5"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2188bc33d85951ea4ddad55d2b35598b2709d122c11c75cffd529fbc9965508e"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0635900d16ae133cab3b26c607586131269f88266954eb04ec31535c9a12ef1e"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57bfc3cf35a0f2fdf0a88a3044aafaec1d2f24d8ae8cd87c4f58d615fb5b6311"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:fe58ef6a764de7b4b36edfc8592641f56e69b7163bba9f9c8089838ee596bfb2"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d09d930c2d1d621f717bb217bf1fe2584616febb5138d9b3e8cdd26506c3f6d4"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:d40c10326893ecab8a80a53039164a224984339b2c32a6baf55ecbd5b1df6431"},
-    {file = "typed_ast-1.5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fd946abf3c31fb50eee07451a6aedbfff912fcd13cf357363f5b4e834cc5e71a"},
-    {file = "typed_ast-1.5.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ed4a1a42df8a3dfb6b40c3d2de109e935949f2f66b19703eafade03173f8f437"},
-    {file = "typed_ast-1.5.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:045f9930a1550d9352464e5149710d56a2aed23a2ffe78946478f7b5416f1ede"},
-    {file = "typed_ast-1.5.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:381eed9c95484ceef5ced626355fdc0765ab51d8553fec08661dce654a935db4"},
-    {file = "typed_ast-1.5.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:bfd39a41c0ef6f31684daff53befddae608f9daf6957140228a08e51f312d7e6"},
-    {file = "typed_ast-1.5.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8c524eb3024edcc04e288db9541fe1f438f82d281e591c548903d5b77ad1ddd4"},
-    {file = "typed_ast-1.5.5-cp38-cp38-win_amd64.whl", hash = "sha256:7f58fabdde8dcbe764cef5e1a7fcb440f2463c1bbbec1cf2a86ca7bc1f95184b"},
-    {file = "typed_ast-1.5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:042eb665ff6bf020dd2243307d11ed626306b82812aba21836096d229fdc6a10"},
-    {file = "typed_ast-1.5.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:622e4a006472b05cf6ef7f9f2636edc51bda670b7bbffa18d26b255269d3d814"},
-    {file = "typed_ast-1.5.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1efebbbf4604ad1283e963e8915daa240cb4bf5067053cf2f0baadc4d4fb51b8"},
-    {file = "typed_ast-1.5.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0aefdd66f1784c58f65b502b6cf8b121544680456d1cebbd300c2c813899274"},
-    {file = "typed_ast-1.5.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:48074261a842acf825af1968cd912f6f21357316080ebaca5f19abbb11690c8a"},
-    {file = "typed_ast-1.5.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:429ae404f69dc94b9361bb62291885894b7c6fb4640d561179548c849f8492ba"},
-    {file = "typed_ast-1.5.5-cp39-cp39-win_amd64.whl", hash = "sha256:335f22ccb244da2b5c296e6f96b06ee9bed46526db0de38d2f0e5a6597b81155"},
-    {file = "typed_ast-1.5.5.tar.gz", hash = "sha256:94282f7a354f36ef5dbce0ef3467ebf6a258e370ab33d5b40c249fa996e590dd"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -1578,5 +1518,5 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7"
-content-hash = "323ba2d4a2de9c8df81d771b1847782a82a3057ce04b7d032ce824eae924148b"
+python-versions = "^3.8"
+content-hash = "6493ce8a77c761f458ad142d0d2c1de3d1f2b7bdd694eb55eea0f196e308049c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/mila-iqia/milatools"
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 blessed = "^1.18.1"
 sshconf = "^0.2.2"
 questionary = "^1.10.0"

--- a/tests/cli/common.py
+++ b/tests/cli/common.py
@@ -5,8 +5,9 @@ import inspect
 import os
 import sys
 import typing
+from collections.abc import Callable
 from subprocess import CompletedProcess
-from typing import Any, Callable
+from typing import Any
 
 import fabric
 import paramiko.ssh_exception
@@ -15,7 +16,7 @@ from pytest_regressions.file_regression import FileRegressionFixture
 from typing_extensions import ParamSpec
 
 if typing.TYPE_CHECKING:
-    from typing_extensions import TypeGuard
+    from typing import TypeGuard
 
 in_github_CI = all(var in os.environ for var in ["CI", "GITHUB_ACTION", "GITHUB_ENV"])
 """True if this is being run inside the GitHub CI."""

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Generator
+from collections.abc import Generator
 from unittest.mock import Mock
 
 import paramiko.ssh_exception

--- a/tests/cli/test_remote.py
+++ b/tests/cli/test_remote.py
@@ -7,8 +7,8 @@ import time
 import typing
 import unittest
 import unittest.mock
+from collections.abc import Callable, Generator, Iterable
 from pathlib import Path
-from typing import Callable, Generator, Iterable
 from unittest.mock import Mock
 
 import invoke
@@ -283,10 +283,7 @@ def test_get_output(
     assert len(mock_connection.method_calls) == 1
     mock_connection.run.assert_called_once()
 
-    if sys.version_info < (3, 8):
-        assert mock_connection.run.mock_calls[0][1] == (command,)
-    else:
-        assert mock_connection.run.mock_calls[0].args[0] == command
+    assert mock_connection.run.mock_calls[0].args[0] == command
     mock_result.stdout.strip.assert_called_once_with()
 
 
@@ -398,10 +395,7 @@ def test_puttext(remote: Remote, tmp_path: Path):
     some_text = "foo"
     _result = remote.puttext(some_text, str(dest))
     remote.connection.run.assert_called_once()
-    if sys.version_info < (3, 8):
-        assert remote.connection.run.mock_calls[0][1] == (f"mkdir -p {dest_dir}",)
-    else:
-        assert remote.connection.run.mock_calls[0].args[0] == f"mkdir -p {dest_dir}"
+    assert remote.connection.run.mock_calls[0].args[0] == f"mkdir -p {dest_dir}"
     # The first argument of `put` will be the name of a temporary file.
     remote.connection.put.assert_called_once_with(unittest.mock.ANY, str(dest))
     assert dest.read_text() == some_text
@@ -410,10 +404,7 @@ def test_puttext(remote: Remote, tmp_path: Path):
 def test_home(remote: Remote):
     home_dir = remote.home()
     remote.connection.run.assert_called_once()
-    if sys.version_info < (3, 8):
-        assert remote.connection.run.mock_calls[0][1] == ("echo $HOME",)
-    else:
-        assert remote.connection.run.mock_calls[0].args[0] == "echo $HOME"
+    assert remote.connection.run.mock_calls[0].args[0] == "echo $HOME"
     remote.connection.local.assert_not_called()
     if remote.hostname == "mila":
         assert home_dir.startswith("/home/mila/")

--- a/tests/cli/test_slurm_remote.py
+++ b/tests/cli/test_slurm_remote.py
@@ -90,7 +90,7 @@ def cancel_all_milatools_jobs_before_and_after_tests(cluster: str):
     login_node._run("squeue --me", echo=True, in_stream=False)
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def get_slurm_account(cluster: str) -> str:
     """Gets the SLURM account of the user using sacctmgr on the slurm cluster.
 

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -68,7 +68,7 @@ def test_hostname():
         ("beluga", cnode, cnode)
         for prefix in ["nc", "ng"]
         for cnode in [f"{prefix}12345"]
-    ]
+    ],
     # NOTE: Not including niagara for now, since DRAC users don't automatically get
     # access to it (plus, it doesn't have GPUs).
     # + [

--- a/tests/cli/test_vscode_utils.py
+++ b/tests/cli/test_vscode_utils.py
@@ -5,10 +5,9 @@ import json
 import shutil
 import tarfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, get_args
 
 import pytest
-from typing_extensions import Literal, get_args
 
 from milatools.cli.remote import Remote
 from milatools.cli.vscode_utils import (


### PR DESCRIPTION
- Drops support for Python 3.7:
- Updates the pre-commit hooks to include the --select=UP flag (pyupgrade equivalent with ruff)
- Updates the build workflow
- Removes unnecessary checks / imports from python 3.7