### PR TITLE
Try to fix the publish workflow (pycparser error)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: poetry
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
There's this weird bug happening in the Publish workflow: https://github.com/mila-iqia/milatools/actions/runs/7847642067/job/21417320491#step:5:53

I suspect that this might have to do with the cache used when installing packages. I'm going to try to disable it and see if it helps.
I'm not sure what the best workflow would be to debug this.