### PR TITLE
Change ControlPersist from 600 to 'yes'

### DIFF
--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -38,8 +38,8 @@ else:
         # This makes a file per connection, like
         # normandf@login.server.mila.quebec:2222
         "ControlPath": r"~/.cache/ssh/%r@%h:%p",
-        # persist for 10 minutes after the last connection ends.
-        "ControlPersist": 600,
+        # persist forever (at least while the local machine is turned on).
+        "ControlPersist": "yes",
     }
 
 

--- a/tests/cli/test_init_command/test_fixes_overly_general_entry.txt
+++ b/tests/cli/test_init_command/test_fixes_overly_general_entry.txt
@@ -7,7 +7,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -28,5 +28,5 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob

--- a/tests/cli/test_init_command/test_setup_ssh_empty_confirm_changes_drac_.md
+++ b/tests/cli/test_init_command/test_setup_ssh_empty_confirm_changes_drac_.md
@@ -13,7 +13,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -34,14 +34,14 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_setup_ssh_empty_confirm_changes_no_drac_.md
+++ b/tests/cli/test_init_command/test_setup_ssh_empty_confirm_changes_no_drac_.md
@@ -13,7 +13,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -34,6 +34,6 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 ```

--- a/tests/cli/test_init_command/test_setup_ssh_has_comment_and_entry_confirm_changes_drac_.md
+++ b/tests/cli/test_init_command/test_setup_ssh_has_comment_and_entry_confirm_changes_drac_.md
@@ -27,7 +27,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -48,14 +48,14 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_setup_ssh_has_comment_and_entry_confirm_changes_no_drac_.md
+++ b/tests/cli/test_init_command/test_setup_ssh_has_comment_and_entry_confirm_changes_no_drac_.md
@@ -27,7 +27,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -48,6 +48,6 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 ```

--- a/tests/cli/test_init_command/test_setup_ssh_has_comment_and_entry_with_extra_space_confirm_changes_drac_.md
+++ b/tests/cli/test_init_command/test_setup_ssh_has_comment_and_entry_with_extra_space_confirm_changes_drac_.md
@@ -35,7 +35,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -56,14 +56,14 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_setup_ssh_has_comment_and_entry_with_extra_space_confirm_changes_no_drac_.md
+++ b/tests/cli/test_init_command/test_setup_ssh_has_comment_and_entry_with_extra_space_confirm_changes_no_drac_.md
@@ -35,7 +35,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -56,6 +56,6 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 ```

--- a/tests/cli/test_init_command/test_setup_ssh_has_comment_confirm_changes_drac_.md
+++ b/tests/cli/test_init_command/test_setup_ssh_has_comment_confirm_changes_drac_.md
@@ -19,7 +19,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -40,14 +40,14 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_setup_ssh_has_comment_confirm_changes_no_drac_.md
+++ b/tests/cli/test_init_command/test_setup_ssh_has_comment_confirm_changes_no_drac_.md
@@ -19,7 +19,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -40,6 +40,6 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 ```

--- a/tests/cli/test_init_command/test_setup_ssh_has_different_indent_confirm_changes_drac_.md
+++ b/tests/cli/test_init_command/test_setup_ssh_has_different_indent_confirm_changes_drac_.md
@@ -23,7 +23,7 @@ Host mila
     ServerAliveCountMax 5
     ControlMaster auto
     ControlPath ~/.cache/ssh/%r@%h:%p
-    ControlPersist 600
+    ControlPersist yes
     User bob
 
 Host mila-cpu
@@ -44,14 +44,14 @@ Host *.server.mila.quebec !*login.server.mila.quebec
     ProxyJump mila
     ControlMaster auto
     ControlPath ~/.cache/ssh/%r@%h:%p
-    ControlPersist 600
+    ControlPersist yes
     User bob
 
 Host beluga cedar graham narval niagara
     HostName %h.alliancecan.ca
     ControlMaster auto
     ControlPath ~/.cache/ssh/%r@%h:%p
-    ControlPersist 600
+    ControlPersist yes
     User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_setup_ssh_has_different_indent_confirm_changes_no_drac_.md
+++ b/tests/cli/test_init_command/test_setup_ssh_has_different_indent_confirm_changes_no_drac_.md
@@ -23,7 +23,7 @@ Host mila
     ServerAliveCountMax 5
     ControlMaster auto
     ControlPath ~/.cache/ssh/%r@%h:%p
-    ControlPersist 600
+    ControlPersist yes
     User bob
 
 Host mila-cpu
@@ -44,6 +44,6 @@ Host *.server.mila.quebec !*login.server.mila.quebec
     ProxyJump mila
     ControlMaster auto
     ControlPath ~/.cache/ssh/%r@%h:%p
-    ControlPersist 600
+    ControlPersist yes
     User bob
 ```

--- a/tests/cli/test_init_command/test_setup_windows_ssh_config_from_wsl_accept_.md
+++ b/tests/cli/test_init_command/test_setup_windows_ssh_config_from_wsl_accept_.md
@@ -9,7 +9,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -30,14 +30,14 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_setup_windows_ssh_config_from_wsl_reject_.md
+++ b/tests/cli/test_init_command/test_setup_windows_ssh_config_from_wsl_reject_.md
@@ -9,7 +9,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -30,14 +30,14 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_has_mila_cpu_entry_has_mila_entry_has_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_has_mila_cpu_entry_has_mila_entry_has_drac_entries_.md
@@ -50,7 +50,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 
 Host mila-cpu
   HostName login.server.mila.quebec
@@ -71,7 +71,7 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 
@@ -81,7 +81,7 @@ Host beluga cedar graham narval niagara
   User bob
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 Host mist
   Hostname mist.scinet.utoronto.ca
   User bob

--- a/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_has_mila_cpu_entry_has_mila_entry_no_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_has_mila_cpu_entry_has_mila_entry_no_drac_entries_.md
@@ -26,7 +26,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 
 Host mila-cpu
   HostName login.server.mila.quebec
@@ -47,14 +47,14 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_has_mila_cpu_entry_no_mila_entry_has_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_has_mila_cpu_entry_no_mila_entry_has_drac_entries_.md
@@ -56,7 +56,7 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 
@@ -66,7 +66,7 @@ Host beluga cedar graham narval niagara
   User bob
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 Host mist
   Hostname mist.scinet.utoronto.ca
   User bob
@@ -94,6 +94,6 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 ```

--- a/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_has_mila_cpu_entry_no_mila_entry_no_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_has_mila_cpu_entry_no_mila_entry_no_drac_entries_.md
@@ -32,7 +32,7 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila
@@ -43,14 +43,14 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_no_mila_cpu_entry_has_mila_entry_has_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_no_mila_cpu_entry_has_mila_entry_has_drac_entries_.md
@@ -47,14 +47,14 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 
 Host *.server.mila.quebec !*login.server.mila.quebec
   HostName %h
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 
@@ -64,7 +64,7 @@ Host beluga cedar graham narval niagara
   User bob
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 Host mist
   Hostname mist.scinet.utoronto.ca
   User bob

--- a/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_no_mila_cpu_entry_has_mila_entry_no_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_no_mila_cpu_entry_has_mila_entry_no_drac_entries_.md
@@ -23,14 +23,14 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 
 Host *.server.mila.quebec !*login.server.mila.quebec
   HostName %h
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -50,7 +50,7 @@ Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_no_mila_cpu_entry_no_mila_entry_has_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_no_mila_cpu_entry_no_mila_entry_has_drac_entries_.md
@@ -39,7 +39,7 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 
@@ -49,7 +49,7 @@ Host beluga cedar graham narval niagara
   User bob
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 Host mist
   Hostname mist.scinet.utoronto.ca
   User bob
@@ -77,7 +77,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu

--- a/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_no_mila_cpu_entry_no_mila_entry_no_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_has_mila_compute_entry_no_mila_cpu_entry_no_mila_entry_no_drac_entries_.md
@@ -15,7 +15,7 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila
@@ -26,7 +26,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -46,7 +46,7 @@ Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_has_mila_cpu_entry_has_mila_entry_has_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_has_mila_cpu_entry_has_mila_entry_has_drac_entries_.md
@@ -47,7 +47,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 
 Host mila-cpu
   HostName login.server.mila.quebec
@@ -70,7 +70,7 @@ Host beluga cedar graham narval niagara
   User bob
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 Host mist
   Hostname mist.scinet.utoronto.ca
   User bob
@@ -95,6 +95,6 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 ```

--- a/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_has_mila_cpu_entry_has_mila_entry_no_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_has_mila_cpu_entry_has_mila_entry_no_drac_entries_.md
@@ -23,7 +23,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 
 Host mila-cpu
   HostName login.server.mila.quebec
@@ -44,14 +44,14 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_has_mila_cpu_entry_no_mila_entry_has_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_has_mila_cpu_entry_no_mila_entry_has_drac_entries_.md
@@ -55,7 +55,7 @@ Host beluga cedar graham narval niagara
   User bob
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 Host mist
   Hostname mist.scinet.utoronto.ca
   User bob
@@ -83,7 +83,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host *.server.mila.quebec !*login.server.mila.quebec
@@ -91,6 +91,6 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 ```

--- a/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_has_mila_cpu_entry_no_mila_entry_no_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_has_mila_cpu_entry_no_mila_entry_no_drac_entries_.md
@@ -32,7 +32,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host *.server.mila.quebec !*login.server.mila.quebec
@@ -40,14 +40,14 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_no_mila_cpu_entry_has_mila_entry_has_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_no_mila_cpu_entry_has_mila_entry_has_drac_entries_.md
@@ -44,7 +44,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 
 
 # Compute Canada
@@ -53,7 +53,7 @@ Host beluga cedar graham narval niagara
   User bob
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 Host mist
   Hostname mist.scinet.utoronto.ca
   User bob
@@ -91,6 +91,6 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 ```

--- a/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_no_mila_cpu_entry_has_mila_entry_no_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_no_mila_cpu_entry_has_mila_entry_no_drac_entries_.md
@@ -20,7 +20,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 
 Host mila-cpu
   Port 2222
@@ -40,14 +40,14 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????

--- a/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_no_mila_cpu_entry_no_mila_entry_has_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_no_mila_cpu_entry_no_mila_entry_has_drac_entries_.md
@@ -38,7 +38,7 @@ Host beluga cedar graham narval niagara
   User bob
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
 Host mist
   Hostname mist.scinet.utoronto.ca
   User bob
@@ -66,7 +66,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -87,6 +87,6 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 ```

--- a/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_no_mila_cpu_entry_no_mila_entry_no_drac_entries_.md
+++ b/tests/cli/test_init_command/test_with_existing_entries_no_mila_compute_entry_no_mila_cpu_entry_no_mila_entry_no_drac_entries_.md
@@ -13,7 +13,7 @@ Host mila
   ServerAliveCountMax 5
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host mila-cpu
@@ -34,14 +34,14 @@ Host *.server.mila.quebec !*login.server.mila.quebec
   ProxyJump mila
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host beluga cedar graham narval niagara
   HostName %h.alliancecan.ca
   ControlMaster auto
   ControlPath ~/.cache/ssh/%r@%h:%p
-  ControlPersist 600
+  ControlPersist yes
   User bob
 
 Host !beluga  bc????? bg????? bl?????


### PR DESCRIPTION
This makes it much more convenient to connect to clusters where 2FA is enabled, as the procedure needs to be done only one per machine boot (instead of once every 10 minutes).