### PR TITLE
Add `ComputeNode`, `LocalV2` + deprecate `RemoteV1` and `LocalV1`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests
         env_vars: PLATFORM,PYTHON
@@ -139,6 +140,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           flags: integrationtests
           env_vars: PLATFORM,PYTHON

--- a/milatools/cli/__init__.py
+++ b/milatools/cli/__init__.py
@@ -1,10 +1,3 @@
 from rich.console import Console
 
-from .utils import currently_in_a_test
-
-if currently_in_a_test():
-    # Make the console very wide so commands are not wrapped across multiple lines.
-    # This makes tests that check the output of commands easier to write.
-    console = Console(record=True, width=200, log_time=False, log_path=False)
-else:
-    console = Console(record=True)
+console = Console(record=True)

--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -58,8 +58,8 @@ from .utils import (
     T,
     cluster_to_connect_kwargs,
     currently_in_a_test,
-    get_fully_qualified_hostname_of_compute_node,
     get_fully_qualified_name,
+    get_hostname_to_use_for_compute_node,
     make_process,
     no_internet_on_compute_nodes,
     randname,
@@ -641,7 +641,7 @@ def code(
     # NOTE: Since we have the config entries for the DRAC compute nodes, there is no
     # need to use the fully qualified hostname here.
     if cluster == "mila":
-        node_name = get_fully_qualified_hostname_of_compute_node(node_name)
+        node_name = get_hostname_to_use_for_compute_node(node_name)
 
     # Try to detect if this is being run from within the Windows Subsystem for Linux.
     # If so, then we run `code` through a powershell.exe command to open VSCode without
@@ -1110,7 +1110,7 @@ def _standard_server(
 
     local_proc, local_port = _forward(
         local=LocalV1(),
-        node=get_fully_qualified_hostname_of_compute_node(node_name, cluster="mila"),
+        node=get_hostname_to_use_for_compute_node(node_name, cluster="mila"),
         to_forward=to_forward,
         options=options,
         port=port,
@@ -1275,7 +1275,7 @@ def _find_allocation(
         exit("ERROR: --node, --job and --alloc are mutually exclusive")
 
     if node is not None:
-        node_name = get_fully_qualified_hostname_of_compute_node(node, cluster=cluster)
+        node_name = get_hostname_to_use_for_compute_node(node, cluster=cluster)
         return RemoteV1(
             node_name, connect_kwargs=cluster_to_connect_kwargs.get(cluster)
         )

--- a/milatools/utils/compute_node.py
+++ b/milatools/utils/compute_node.py
@@ -1,0 +1,512 @@
+from __future__ import annotations
+
+import asyncio.subprocess
+import contextlib
+import dataclasses
+import datetime
+import re
+import shlex
+import subprocess
+import sys
+import warnings
+
+from milatools.cli import console
+from milatools.cli.utils import (
+    MilatoolsUserError,
+    get_hostname_to_use_for_compute_node,
+    stripped_lines_of,
+)
+from milatools.utils.remote_v1 import Hide
+from milatools.utils.remote_v2 import RemoteV2, logger, ssh_command
+from milatools.utils.runner import Runner
+
+JOB_NOT_RUNNING_MESSAGE = (
+    "ComputeNode for job {job_id} has been closed and is unusable, since the job has "
+    "already ended!"
+)
+
+
+class JobNotRunningError(RuntimeError):
+    """Raised when trying to call `run` or `run_async` on a ComputeNode whose job has
+    already been closed."""
+
+    def __init__(self, job_id: int, *args: object) -> None:
+        super().__init__(JOB_NOT_RUNNING_MESSAGE.format(job_id=job_id), *args)
+        self.job_id = job_id
+
+
+@dataclasses.dataclass
+class ComputeNode(Runner):
+    """Runs commands on a compute node with `srun --jobid {job_id}` from the login node.
+
+    This essentially runs this:
+    `ssh {cluster} srun --overlap --jobid {job_id} {command}`
+    in a subprocess each time `run` is called.
+
+    NOTE: Found out about this trick from https://hpc.fau.de/faq/how-can-i-attach-to-a-running-slurm-job/
+    """
+
+    login_node: RemoteV2
+    """The login node of the SLURM cluster."""
+
+    job_id: int
+    """The job ID of the job running on the compute node."""
+
+    salloc_subprocess: asyncio.subprocess.Process | None = dataclasses.field(
+        default=None, repr=False, compare=False
+    )
+    """A handle to the subprocess that is running the `salloc` command."""
+
+    hostname: str = dataclasses.field(init=False)
+
+    _closed: bool = dataclasses.field(default=False, init=False, repr=False)
+
+    def __post_init__(self):
+        node_name = self.get_output("echo $SLURMD_NODENAME", display=False, hide=True)
+        # We show the hostname of the compute node during commands, even though we're
+        # actually running `ssh <login-node> srun --jobid <job-id> <command>`
+        cluster = self.login_node.hostname
+        self.hostname: str = get_hostname_to_use_for_compute_node(
+            node_name,
+            cluster=cluster,
+            ssh_config_path=self.login_node.ssh_config_path,
+        )
+
+    @staticmethod
+    async def connect(
+        login_node: RemoteV2,
+        job_id_or_node_name: int | str,
+    ) -> ComputeNode:
+        return await connect_to_running_job(
+            login_node=login_node, jobid_or_nodename=job_id_or_node_name
+        )
+
+    def run(
+        self, command: str, display: bool = True, warn: bool = False, hide: Hide = False
+    ):
+        srun_command, input = self._get_srun_command_and_input(command, display=display)
+        return self.login_node.run(
+            command=srun_command,
+            input=input,
+            display=False,
+            warn=warn,
+            hide=hide,
+        )
+
+    async def run_async(
+        self,
+        command: str,
+        display: bool = True,
+        warn: bool = False,
+        hide: Hide = False,
+    ) -> subprocess.CompletedProcess[str]:
+        srun_command, input = self._get_srun_command_and_input(command, display=display)
+        return await self.login_node.run_async(
+            command=srun_command,
+            input=input,
+            display=False,
+            warn=warn,
+            hide=hide,
+        )
+
+    def _get_srun_command_and_input(self, command: str, display: bool):
+        """Common portion of `run` and `run_async`."""
+        if self._closed:
+            raise JobNotRunningError(self.job_id)
+        if display:
+            # Show the compute node hostname instead of the login node.
+            console.log(f"({self.hostname}) $ {command}", style="green")
+
+        if shlex.quote(command) == command:
+            # The command is simple and doesn't need to be shell-escaped, so we can run
+            # it directly with `ssh`.
+            srun_command = command
+            input = None
+        else:
+            # The command might have some shell syntax that needs to be preserved, so we run
+            # `ssh (...) bash` and feed the input to the subprocess' stdin.
+            srun_command = "bash"
+            input = command + "\n"
+        srun_command = (
+            f"srun --ntasks=1 --overlap --quiet --jobid {self.job_id} {command}"
+        )
+        return srun_command, input
+
+    def __del__(self):
+        if not self._closed and self.salloc_subprocess:
+            try:
+                self.salloc_subprocess.terminate()
+            except ProcessLookupError:
+                pass  # salloc subprocess has already been terminated.
+            else:
+                # NOTE: We only get here if the job is being deleted without having been
+                # closed.
+                logger.warning(
+                    f"Compute node is being deleted without having been closed!\n"
+                    f"Terminated job {self.job_id} on {self.hostname}."
+                )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *excinfo):
+        self.close()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *excinfo):
+        await self.close_async()
+
+    def close(self):
+        """Ends the job.
+
+        The ComputeNode becomes unusable.
+        """
+        if self._closed:
+            logger.warning(f"Job {self.job_id} has already been closed.")
+            return
+        logger.info(f"Stopping job {self.job_id}.")
+        if self.salloc_subprocess:
+            self.salloc_subprocess.terminate()
+        else:
+            self.login_node.run(f"scancel {self.job_id}")
+        self._closed = True
+
+    async def close_async(self):
+        """Cancels the running job using `scancel`."""
+        if self._closed:
+            logger.warning(f"Job {self.job_id} has already been closed.")
+            return
+        logger.info(f"Stopping job {self.job_id}.")
+        if self.salloc_subprocess is not None:
+            assert self.salloc_subprocess.stdin is not None
+            # NOTE: This will exit cleanly because we don't have nested terminals or
+            # job steps.
+            logger.debug("Exiting the salloc subprocess gracefully.")
+            await self.salloc_subprocess.communicate("exit\n".encode())  # noqa: UP012
+        else:
+            # The scancel below is done even though it's redundant, just to be safe.
+            await self.login_node.run_async(
+                f"scancel {self.job_id}",
+                display=True,
+                hide=False,
+                warn=True,
+            )
+        self._closed = True
+
+
+async def get_queued_milatools_job_ids(
+    login_node: RemoteV2, job_name="mila-code"
+) -> set[int]:
+    # NOTE: `since` is unused in this case.
+    jobs = await login_node.get_output_async(
+        f"squeue --noheader --me --format=%A --name={job_name}"
+    )
+    return set([int(job_id_str) for job_id_str in jobs.splitlines()])
+
+
+async def get_milatools_job_ids(
+    login_node: RemoteV2,
+    job_name="mila-code",
+    since: datetime.timedelta = datetime.timedelta(hours=1),
+) -> set[int]:
+    """Get the IDS of jobs created by milatools from the output of `sacct`."""
+    jobs = await login_node.get_output_async(
+        f"sacct --noheader --allocations --user=$USER "
+        f"--starttime=now-{int(since.total_seconds())}seconds --format=JobId "
+        f"--name={job_name}"
+    )
+    return set([int(job_id_str) for job_id_str in jobs.splitlines()])
+
+
+@contextlib.asynccontextmanager
+async def cancel_new_jobs_on_interrupt(login_node: RemoteV2, job_name: str):
+    """ContextManager that handles interruptions while creating a new allocation.
+
+    This handles the case where an interrupt is raised while running a command over SSH
+    that creates a new job allocation (either salloc or sbatch) before we are able to
+    parse the job id. (In the case where we have the job ID, we simply use
+    `scancel {job_id}`).
+
+    In this case, we try to cancel the new job(s) that have appeared since entering the
+    `async with` block that have the name `job_name`. Emits a warning in the (unlikely)
+    case where such jobs are not found, as it means that there could be a "zombie" job
+    allocation on the cluster.
+    """
+    jobs_before = await get_queued_milatools_job_ids(login_node, job_name=job_name)
+    if jobs_before:
+        logger.info(
+            f"Existing jobs on {login_node.hostname} with name {job_name}: {jobs_before}"
+        )
+    else:
+        logger.debug(
+            f"There are currently no jobs with name {job_name} on {login_node.hostname}."
+        )
+    try:
+        yield
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        jobs_after = await get_queued_milatools_job_ids(login_node, job_name=job_name)
+        logger.warning("Interrupted before we were able to parse a job id!")
+        # We were unable to get the job id, so we'll try to cancel only the newly
+        # spawned jobs from this user that match the set name.
+        new_jobs = list(set(jobs_after) - set(jobs_before))
+        if len(new_jobs) == 1:
+            job_id = new_jobs[0]
+            console.log(
+                f"Cancelling job {job_id} since it is the only new job of this "
+                f"user with name {job_name!r} since the last call to salloc or sbatch.",
+                style="yellow",
+            )
+            login_node.run(f"scancel {new_jobs[0]}", display=True, hide=False)
+        elif len(new_jobs) > 1:
+            console.log(
+                f"There appears to be more than one new jobs from this user with "
+                f"name {job_name!r} since the initial call to salloc or sbatch: "
+                f"{new_jobs}\n"
+                "Cancelling all of them to be safe...",
+                style="yellow",
+            )
+            await asyncio.shield(
+                login_node.run_async(
+                    "scancel " + " ".join(str(job_id) for job_id in new_jobs),
+                    display=True,
+                    hide=False,
+                )
+            )
+        else:
+            warnings.warn(
+                RuntimeWarning(
+                    f"Unable to find any new job IDs with name {job_name!r} since the last "
+                    f"job allocation. This means that if job allocations were created, "
+                    "they might not have been properly cancelled. Please check that there "
+                    f"are no leftover jobs with {job_name!r} on the cluster!"
+                )
+            )
+        raise
+
+
+async def salloc(
+    login_node: RemoteV2, salloc_flags: list[str], job_name: str
+) -> ComputeNode:
+    """Runs `salloc` and returns a remote connected to the compute node."""
+    # NOTE: Some SLURM clusters prevent submitting jobs from $HOME.
+    salloc_command = "cd $SCRATCH && salloc " + shlex.join(salloc_flags)
+    command = ssh_command(
+        hostname=login_node.hostname,
+        control_path=login_node.control_path,
+        control_master="auto",
+        control_persist="yes",
+        command=salloc_command,
+        ssh_config_path=login_node.ssh_config_path,
+    )
+
+    salloc_subprocess = None
+    job_id: int | None = None
+
+    # "Why not just use `subprocess.Popen`?", you might ask. Well, we're essentially
+    # trying to go full-async so that the parsing of the job-id from stderr can
+    # eventually be done at the same time as something else (while waiting for the
+    # job to start) using things like `asyncio.gather` and `asyncio.wait_for`.
+    logger.debug(f"(local) $ {shlex.join(command)}")
+    console.log(
+        f"({login_node.hostname}) $ {salloc_command}", style="green", markup=False
+    )
+    async with cancel_new_jobs_on_interrupt(login_node, job_name):
+        # BUG: IF stdin is not set (or set to PIPE?) then writing `salloc`, then the
+        # terminal is actually 'live' and affects the compute node! For instance if
+        # you do `mila code .` and then write `salloc`, it spawns a second job!!
+        salloc_subprocess = await asyncio.subprocess.create_subprocess_exec(
+            *command,
+            shell=False,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        assert salloc_subprocess.stderr is not None
+        while job_id is None:
+            error_line = (await salloc_subprocess.stderr.readline()).decode()
+            print(error_line, end="", file=sys.stderr)
+            if job_id_match := re.findall(r"job allocation [0-9]+", error_line):
+                job_id = int(job_id_match[0].split()[-1])
+                break
+            if not error_line:
+                # Getting an empty line (only?) after salloc errors are done printing.
+                break
+
+    if job_id is None:
+        salloc_subprocess.kill()
+        raise RuntimeError("Unable to parse the job ID from the output of salloc!")
+
+    try:
+        console.log(f"Waiting for job {job_id} to start.", style="green")
+        await wait_while_job_is_pending(login_node, job_id)
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        if salloc_subprocess is not None:
+            logger.debug("Killing the salloc subprocess following a KeyboardInterrupt.")
+            await salloc_subprocess.communicate("exit\n".encode())  # noqa: UP012
+            # salloc_subprocess.send_signal(signal.SIGINT)
+            # salloc_subprocess.send_signal(signal.SIGKILL)
+            # salloc_subprocess.terminate()
+        await login_node.run_async(f"scancel {job_id}", display=True, hide=False)
+        raise
+
+    # todo: Are there are states between `PENDING` and `RUNNING`?
+    # if state != "RUNNING":
+    #     raise RuntimeError(
+    #         f"Error: Expected job {job_id} to be running, but it is in state {state!r}!"
+    #     )
+
+    # NOTE: passing the process handle to this ComputeNodeRemote so it doesn't go out of
+    # scope and die (which would maybe kill the job, not 100% sure).
+
+    return ComputeNode(
+        job_id=job_id,
+        login_node=login_node,
+        salloc_subprocess=salloc_subprocess,
+    )
+
+
+async def sbatch(
+    login_node: RemoteV2, sbatch_flags: list[str], job_name: str
+) -> ComputeNode:
+    """Runs `sbatch` and returns a remote connected to the compute node.
+
+    The job script is actually the `sleep` command wrapped in an sbatch script thanks to
+    [the '--wrap' argument of sbatch](https://slurm.schedmd.com/sbatch.html#OPT_wrap)
+
+    This then waits asynchronously while the job show up as PENDING in the output of the
+    `sacct` command.
+    """
+    # NOTE: cd to $SCRATCH because some SLURM clusters prevent submitting jobs from the
+    # HOME directory. Also, if a cluster doesn't have $SCRACTCH set, we just stay in the
+    # home directory, so no harm done.
+    # Also, should we use --ntasks=1 --overlap in the wrapped `srun`, so that only one
+    # task sleeps? Does that change anything?
+    sbatch_command = (
+        "cd $SCRATCH && sbatch --parsable "
+        + shlex.join(sbatch_flags)
+        + " --wrap 'srun sleep 7d'"
+    )
+
+    job_id = None
+    async with cancel_new_jobs_on_interrupt(login_node, job_name):
+        job_id = await login_node.get_output_async(
+            sbatch_command, display=True, hide=False
+        )
+        job_id = int(job_id)
+
+    try:
+        await wait_while_job_is_pending(login_node, job_id)
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        console.log(f"Received KeyboardInterrupt, cancelling job {job_id}")
+        login_node.run(f"scancel {job_id}", display=True, hide=False)
+        raise
+
+    return ComputeNode(job_id=job_id, login_node=login_node)
+
+
+async def _wait_while_job_is_in_state(login_node: RemoteV2, job_id: int, state: str):
+    nodes: str | None = None
+    current_state: str | None = None
+    wait_time_seconds = 1
+    attempt = 1
+
+    while True:
+        result = await login_node.run_async(
+            f"sacct --jobs {job_id} --allocations --noheader --format=Node,State",
+            display=False,
+            warn=True,  # don't raise an error if the command fails.
+            hide=True,
+        )
+        stdout = result.stdout.strip()
+        nodes, _, current_state = stdout.rpartition(" ")
+        nodes = nodes.strip()
+        current_state = current_state.strip()
+        logger.debug(f"{nodes=}, {current_state=}")
+
+        if (
+            result.returncode == 0
+            and nodes
+            and nodes != "None assigned"
+            and current_state
+            and current_state != state
+        ):
+            logger.info(
+                f"Job {job_id} was allocated node(s) {nodes!r} and is in state "
+                f"{current_state!r}."
+            )
+            return current_state
+
+        waiting_until = f"Waiting {wait_time_seconds} seconds until job {job_id} "
+        condition: str | None = None
+        if result.returncode == 0 and not nodes and not current_state:
+            condition = "shows up in the output of `sacct`."
+        elif result.returncode != 0:
+            # todo: Look into this case a bit more deeply. Seems like sometimes sacct
+            # gives errors for example right after salloc, when the job id is not yet
+            # in the slurm DB.
+            condition = "shows up in the output of `sacct`."
+        elif nodes == "None assigned":
+            condition = "is allocated a node."
+        elif current_state == state:
+            condition = f"is no longer {state}."
+        else:
+            # TODO: Don't yet understand when this case could occur.
+            logger.warning(
+                f"Unexpected result from `sacct` for job {job_id}: {result.stdout=}, {result.stderr=}"
+            )
+            condition = "shows up correctly in the output of sacct."
+        logger.info(waiting_until + condition)
+
+        if attempt > 1:
+            logger.debug(f"Attempt #{attempt}")
+
+        await asyncio.sleep(wait_time_seconds)
+        wait_time_seconds *= 2
+        # wait at most 30 seconds for each attempt.
+        wait_time_seconds = min(30, wait_time_seconds)
+        attempt += 1
+
+
+async def wait_while_job_is_pending(login_node: RemoteV2, job_id: int) -> str:
+    """Waits until a job show up in `sacct` then waits until its state is not PENDING.
+
+    Returns the `State` from `sacct` after the job is no longer pending.
+    """
+    return await _wait_while_job_is_in_state(login_node, job_id, state="PENDING")
+
+
+async def connect_to_running_job(
+    jobid_or_nodename: int | str,
+    login_node: RemoteV2,
+) -> ComputeNode:
+    # The `--job` flag used to be a string, might still be for some commands, so convert
+    # an int string to int here just to be safe.
+    if isinstance(jobid_or_nodename, str) and jobid_or_nodename.isdigit():
+        jobid_or_nodename = int(jobid_or_nodename)
+
+    if isinstance(jobid_or_nodename, int):
+        job_id = jobid_or_nodename
+        await wait_while_job_is_pending(login_node, job_id=job_id)
+        return ComputeNode(login_node, job_id=job_id)
+
+    node_name = jobid_or_nodename
+    # we have to find the job id to use on the given node.
+    jobs_on_node = await login_node.get_output_async(
+        f"squeue --me --node {node_name} --noheader --format=%A"
+    )
+    jobs_on_node = [int(line) for line in stripped_lines_of(jobs_on_node)]
+
+    if len(jobs_on_node) == 0:
+        raise MilatoolsUserError(
+            f"You don't appear to have any jobs currently running on node {node_name}. "
+            "Please check again or specify the job id to connect to."
+        )
+    if len(jobs_on_node) > 1:
+        raise MilatoolsUserError(
+            f"You have more than one job running on node {node_name}: {jobs_on_node}.\n"
+            "please use the `--job` flag to specify which job to connect to."
+        )
+    assert len(jobs_on_node) == 1
+    return ComputeNode(login_node=login_node, job_id=jobs_on_node[0])

--- a/milatools/utils/compute_node.py
+++ b/milatools/utils/compute_node.py
@@ -120,15 +120,15 @@ class ComputeNode(Runner):
         if shlex.quote(command) == command:
             # The command is simple and doesn't need to be shell-escaped, so we can run
             # it directly with `ssh`.
-            srun_command = command
+            _command = command
             input = None
         else:
             # The command might have some shell syntax that needs to be preserved, so we run
             # `ssh (...) bash` and feed the input to the subprocess' stdin.
-            srun_command = "bash"
+            _command = "bash"
             input = command + "\n"
         srun_command = (
-            f"srun --ntasks=1 --overlap --quiet --jobid {self.job_id} {command}"
+            f"srun --ntasks=1 --overlap --quiet --jobid {self.job_id} {_command}"
         )
         return srun_command, input
 

--- a/milatools/utils/compute_node.py
+++ b/milatools/utils/compute_node.py
@@ -250,12 +250,10 @@ async def cancel_new_jobs_on_interrupt(login_node: RemoteV2, job_name: str):
                 "Cancelling all of them to be safe...",
                 style="yellow",
             )
-            await asyncio.shield(
-                login_node.run_async(
-                    "scancel " + " ".join(str(job_id) for job_id in new_jobs),
-                    display=True,
-                    hide=False,
-                )
+            login_node.run(
+                "scancel " + " ".join(str(job_id) for job_id in new_jobs),
+                display=True,
+                hide=False,
             )
         else:
             warnings.warn(

--- a/milatools/utils/compute_node.py
+++ b/milatools/utils/compute_node.py
@@ -55,6 +55,7 @@ class ComputeNode(Runner):
     """A handle to the subprocess that is running the `salloc` command."""
 
     hostname: str = dataclasses.field(init=False)
+    """Name of the compute node, as seen in `squeue`, `sacct` or `$SLURMD_NODENAME`."""
 
     _closed: bool = dataclasses.field(default=False, init=False, repr=False)
 

--- a/milatools/utils/compute_node.py
+++ b/milatools/utils/compute_node.py
@@ -134,15 +134,12 @@ class ComputeNode(Runner):
         if not self._closed and self.salloc_subprocess:
             try:
                 self.salloc_subprocess.terminate()
-            except ProcessLookupError:
-                pass  # salloc subprocess has already been terminated.
-            else:
-                # NOTE: We only get here if the job is being deleted without having been
-                # closed.
                 logger.warning(
                     f"Compute node is being deleted without having been closed!\n"
                     f"Terminated job {self.job_id} on {self.hostname}."
                 )
+            except ProcessLookupError:
+                pass  # salloc subprocess had already been killed, all good.
 
     def __enter__(self):
         return self

--- a/milatools/utils/compute_node.py
+++ b/milatools/utils/compute_node.py
@@ -198,7 +198,6 @@ class ComputeNode(Runner):
 async def get_queued_milatools_job_ids(
     login_node: RemoteV2, job_name="mila-code"
 ) -> set[int]:
-    # NOTE: `since` is unused in this case.
     jobs = await login_node.get_output_async(
         f"squeue --noheader --me --format=%A --name={job_name}"
     )

--- a/milatools/utils/compute_node.py
+++ b/milatools/utils/compute_node.py
@@ -317,18 +317,16 @@ async def salloc(
     except (KeyboardInterrupt, asyncio.CancelledError):
         logger.debug("Killing the salloc subprocess following a KeyboardInterrupt.")
         salloc_subprocess.terminate()
-        await login_node.run_async(f"scancel {job_id}", display=True, hide=False)
+        login_node.run(f"scancel {job_id}", display=True, hide=False)
         raise
 
-    # todo: Are there are states between `PENDING` and `RUNNING`?
-    # if state != "RUNNING":
-    #     raise RuntimeError(
-    #         f"Error: Expected job {job_id} to be running, but it is in state {state!r}!"
-    #     )
+    # Note: While there are potentially states between `PENDING` and `RUNNING`, here
+    # we're assuming that if the job is no longer pending, it's probably running. Even
+    # if it isn't true, an informative error will most probably be given to the user by
+    # the first `ssh <cluster> srun --job-id <job_id>` command.
 
     # NOTE: passing the process handle to this ComputeNodeRemote so it doesn't go out of
-    # scope and die (which would maybe kill the job, not 100% sure).
-
+    # scope and die (which would kill the interactive job).
     return ComputeNode(
         job_id=job_id,
         login_node=login_node,

--- a/milatools/utils/compute_node.py
+++ b/milatools/utils/compute_node.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio.subprocess
 import contextlib
 import dataclasses
-import datetime
 import re
 import shlex
 import subprocess
@@ -200,20 +199,6 @@ async def get_queued_milatools_job_ids(
 ) -> set[int]:
     jobs = await login_node.get_output_async(
         f"squeue --noheader --me --format=%A --name={job_name}"
-    )
-    return set([int(job_id_str) for job_id_str in jobs.splitlines()])
-
-
-async def get_milatools_job_ids(
-    login_node: RemoteV2,
-    job_name="mila-code",
-    since: datetime.timedelta = datetime.timedelta(hours=1),
-) -> set[int]:
-    """Get the IDS of jobs created by milatools from the output of `sacct`."""
-    jobs = await login_node.get_output_async(
-        f"sacct --noheader --allocations --user=$USER "
-        f"--starttime=now-{int(since.total_seconds())}seconds --format=JobId "
-        f"--name={job_name}"
     )
     return set([int(job_id_str) for job_id_str in jobs.splitlines()])
 

--- a/milatools/utils/compute_node.py
+++ b/milatools/utils/compute_node.py
@@ -302,14 +302,11 @@ async def salloc(
             stderr=asyncio.subprocess.PIPE,
         )
         assert salloc_subprocess.stderr is not None
-        while job_id is None:
-            error_line = (await salloc_subprocess.stderr.readline()).decode()
+        # Getting an empty line only after salloc errors are done printing.
+        while error_line := (await salloc_subprocess.stderr.readline()).decode():
             print(error_line, end="", file=sys.stderr)
             if job_id_match := re.findall(r"job allocation [0-9]+", error_line):
                 job_id = int(job_id_match[0].split()[-1])
-                break
-            if not error_line:
-                # Getting an empty line (only?) after salloc errors are done printing.
                 break
 
     if job_id is None:

--- a/milatools/utils/compute_node.py
+++ b/milatools/utils/compute_node.py
@@ -20,18 +20,17 @@ from milatools.utils.remote_v1 import Hide
 from milatools.utils.remote_v2 import RemoteV2, logger, ssh_command
 from milatools.utils.runner import Runner
 
-JOB_NOT_RUNNING_MESSAGE = (
-    "ComputeNode for job {job_id} has been closed and is unusable, since the job has "
-    "already ended!"
-)
-
 
 class JobNotRunningError(RuntimeError):
     """Raised when trying to call `run` or `run_async` on a ComputeNode whose job has
     already been closed."""
 
     def __init__(self, job_id: int, *args: object) -> None:
-        super().__init__(JOB_NOT_RUNNING_MESSAGE.format(job_id=job_id), *args)
+        super().__init__(
+            f"ComputeNode for job {job_id} has been closed and is unusable, since the "
+            f"job has already ended!",
+            *args,
+        )
         self.job_id = job_id
 
 

--- a/milatools/utils/compute_node.py
+++ b/milatools/utils/compute_node.py
@@ -75,7 +75,7 @@ class ComputeNode(Runner):
         login_node: RemoteV2,
         job_id_or_node_name: int | str,
     ) -> ComputeNode:
-        return await connect_to_running_job(
+        return await _connect_to_running_job(
             login_node=login_node, jobid_or_nodename=job_id_or_node_name
         )
 
@@ -446,7 +446,7 @@ async def wait_while_job_is_pending(login_node: RemoteV2, job_id: int) -> str:
     return await _wait_while_job_is_in_state(login_node, job_id, state="PENDING")
 
 
-async def connect_to_running_job(
+async def _connect_to_running_job(
     jobid_or_nodename: int | str,
     login_node: RemoteV2,
 ) -> ComputeNode:

--- a/milatools/utils/local_v1.py
+++ b/milatools/utils/local_v1.py
@@ -12,13 +12,13 @@ import fabric
 import paramiko.ssh_exception
 from typing_extensions import deprecated
 
+from milatools.cli.utils import CommandNotFoundError, T, cluster_to_connect_kwargs
 from milatools.utils.remote_v2 import SSH_CONFIG_FILE, is_already_logged_in
-
-from ..cli.utils import CommandNotFoundError, T, cluster_to_connect_kwargs
 
 logger = get_logger(__name__)
 
 
+@deprecated("LocalV1 is being deprecated. Use LocalV2 instead.", category=None)
 class LocalV1:
     def display(self, args: list[str] | tuple[str, ...]) -> None:
         display(args)

--- a/milatools/utils/local_v1.py
+++ b/milatools/utils/local_v1.py
@@ -85,7 +85,7 @@ def check_passwordless(host: str) -> bool:
     if (
         sys.platform != "win32"
         and SSH_CONFIG_FILE.exists()
-        and is_already_logged_in(host)
+        and is_already_logged_in(host, ssh_config_path=SSH_CONFIG_FILE)
     ):
         return True
 

--- a/milatools/utils/local_v2.py
+++ b/milatools/utils/local_v2.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import shlex
+import subprocess
+import sys
+from logging import getLogger as get_logger
+from subprocess import CompletedProcess
+
+from milatools.cli import console
+from milatools.utils.remote_v1 import Hide
+from milatools.utils.runner import Runner
+
+logger = get_logger(__name__)
+
+
+@dataclasses.dataclass(init=False, frozen=True)
+class LocalV2(Runner):
+    """A runner that runs commands in subprocesses on the local machine."""
+
+    hostname = "localhost"
+
+    @staticmethod
+    def run(
+        command: str | tuple[str, ...],
+        input: str | None = None,
+        display: bool = True,
+        warn: bool = False,
+        hide: Hide = False,
+    ) -> CompletedProcess[str]:
+        program_and_args = _display_command(command, input=input, display=display)
+        return run(program_and_args=program_and_args, input=input, warn=warn, hide=hide)
+
+    @staticmethod
+    def get_output(
+        command: str | tuple[str, ...],
+        *,
+        display: bool = False,
+        warn: bool = False,
+        hide: Hide = True,
+    ) -> str:
+        return LocalV2.run(
+            command, display=display, warn=warn, hide=hide
+        ).stdout.strip()
+
+    @staticmethod
+    async def run_async(
+        command: str | tuple[str, ...],
+        input: str | None = None,
+        display: bool = True,
+        warn: bool = False,
+        hide: Hide = False,
+    ) -> CompletedProcess[str]:
+        program_and_args = _display_command(command, input=input, display=display)
+        return await run_async(program_and_args, input=input, warn=warn, hide=hide)
+
+    @staticmethod
+    async def get_output_async(
+        command: str | tuple[str, ...],
+        *,
+        display: bool = False,
+        warn: bool = False,
+        hide: Hide = True,
+    ) -> str:
+        """Runs the command asynchronously and returns the stripped output string."""
+        return (
+            await LocalV2.run_async(command, display=display, warn=warn, hide=hide)
+        ).stdout.strip()
+
+
+def _display_command(
+    command: str | tuple[str, ...], input: str | None, display: bool
+) -> tuple[str, ...]:
+    """Converts the command to a tuple of strings if needed with `shlex.split` and
+    optionally logs it to the console.
+
+    Also shows the input that would be passed to the command, if any.
+    """
+    if isinstance(command, str):
+        program_and_args = tuple(shlex.split(command))
+        displayed_command = command
+    else:
+        program_and_args = command
+        displayed_command = shlex.join(command)
+    if display:
+        if not input:
+            console.log(
+                f"(localhost) $ {displayed_command}",
+                style="green",
+                _stack_offset=2,
+            )
+        else:
+            console.log(
+                f"(localhost) $ {displayed_command}\n{input}",
+                style="green",
+                _stack_offset=2,
+            )
+    return program_and_args
+
+
+def run(
+    program_and_args: tuple[str, ...],
+    input: str | None = None,
+    warn: bool = False,
+    hide: Hide = False,
+) -> subprocess.CompletedProcess[str]:
+    """Runs the command *synchronously* in a subprocess and returns the result.
+
+    Parameters
+    ----------
+    program_and_args: The program and arguments to pass to it. This is a tuple of \
+        strings, same as in `subprocess.Popen`.
+    input: The optional 'input' argument to `subprocess.Popen.communicate()`.
+    warn: When `True` and an exception occurs, warn instead of raising the exception.
+    hide: Controls the printing of the subprocess' stdout and stderr.
+
+    Returns
+    -------
+    The `subprocess.CompletedProcess` object with the result of the subprocess.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If an error occurs when running the command and `warn` is `False`.
+    """
+    displayed_command = shlex.join(program_and_args)
+    if not input:
+        logger.debug(f"Calling `subprocess.run` with {program_and_args=}")
+    else:
+        logger.debug(f"Calling `subprocess.run` with {program_and_args=} and {input=}")
+    result = subprocess.run(
+        program_and_args,
+        shell=False,
+        capture_output=True,
+        text=True,
+        check=not warn,
+        input=input,
+    )
+    assert result.returncode is not None
+    if warn and result.returncode != 0:
+        message = (
+            f"Command {displayed_command!r}"
+            + (f" with {input=!r}" if input else "")
+            + f" exited with {result.returncode}: {result.stderr=}"
+        )
+        logger.debug(message)
+        if hide is not True:  # don't warn if hide is True.
+            logger.warning(RuntimeWarning(message), stacklevel=2)
+
+    if result.stdout:
+        if hide not in [True, "out", "stdout"]:
+            print(result.stdout)
+        logger.debug(f"{result.stdout=}")
+    if result.stderr:
+        if hide not in [True, "err", "stderr"]:
+            print(result.stderr, file=sys.stderr)
+        logger.debug(f"{result.stderr=}")
+    return result
+
+
+async def run_async(
+    program_and_args: tuple[str, ...],
+    input: str | None = None,
+    warn: bool = False,
+    hide: Hide = False,
+) -> subprocess.CompletedProcess[str]:
+    """Runs the command *asynchronously* in a subprocess and returns the result.
+
+    Parameters
+    ----------
+    program_and_args: The program and arguments to pass to it. This is a tuple of \
+        strings, same as in `subprocess.Popen`.
+    input: The optional 'input' argument to `subprocess.Popen.communicate()`.
+    warn: When `True` and an exception occurs, warn instead of raising the exception.
+    hide: Controls the printing of the subprocess' stdout and stderr.
+
+    Returns
+    -------
+    A `subprocess.CompletedProcess` object with the result of the asyncio.Process.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If an error occurs when running the command and `warn` is `False`.
+    """
+
+    logger.debug(f"Calling `asyncio.create_subprocess_exec` with {program_and_args=}")
+    proc = await asyncio.create_subprocess_exec(
+        *program_and_args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        stdin=asyncio.subprocess.PIPE,
+        shell=False,
+    )
+    if input:
+        logger.debug(f"Sending {input=!r} to the subprocess' stdin.")
+    stdout, stderr = await proc.communicate(input.encode() if input else None)
+
+    assert proc.returncode is not None
+    if proc.returncode != 0:
+        message = (
+            f"{program_and_args!r}"
+            + (f" with input {input!r}" if input else "")
+            + f" exited with {proc.returncode}"
+            + (f": {stderr}" if stderr else "")
+        )
+        logger.debug(message)
+        if not warn:
+            if stderr:
+                logger.error(stderr)
+            raise subprocess.CalledProcessError(
+                returncode=proc.returncode,
+                cmd=program_and_args,
+                output=stdout,
+                stderr=stderr,
+            )
+        if hide is not True:  # don't warn if hide is True.
+            logger.warning(RuntimeWarning(message))
+    result = subprocess.CompletedProcess(
+        args=program_and_args,
+        returncode=proc.returncode,
+        stdout=stdout.decode(),
+        stderr=stderr.decode(),
+    )
+    if result.stdout:
+        if hide not in [True, "out", "stdout"]:
+            print(result.stdout)
+        logger.debug(f"{result.stdout}")
+    if result.stderr:
+        if hide not in [True, "err", "stderr"]:
+            print(result.stderr, file=sys.stderr)
+        logger.debug(f"{result.stderr}")
+    return result

--- a/milatools/utils/remote_v1.py
+++ b/milatools/utils/remote_v1.py
@@ -109,6 +109,7 @@ def get_first_node_name(node_names_out: str) -> str:
     return base + inside_brackets.split("-")[0]
 
 
+@deprecated("RemoteV1 is being deprecated. Use RemoteV2 instead.", category=None)
 class RemoteV1:
     def __init__(
         self,
@@ -444,6 +445,7 @@ class RemoteV1:
         return self.extract(shlex.join([dest, *args]), pattern=pattern, **kwargs)
 
 
+@deprecated("SlurmRemote is being deprecated. Use ComputeNode instead.", category=None)
 class SlurmRemote(RemoteV1):
     def __init__(
         self,

--- a/milatools/utils/remote_v2.py
+++ b/milatools/utils/remote_v2.py
@@ -325,7 +325,7 @@ def option_dict_to_flags(options: dict[str, str]) -> list[str]:
     ]
 
 
-def is_already_logged_in(cluster: str) -> bool:
+def is_already_logged_in(cluster: str, ssh_config_path: Path = SSH_CONFIG_FILE) -> bool:
     """Checks whether we are already logged in to the given cluster.
 
     More specifically, this checks whether a reusable SSH control master is setup at the
@@ -333,7 +333,6 @@ def is_already_logged_in(cluster: str) -> bool:
 
     NOTE: This function is not supported on Windows.
     """
-    ssh_config_path = SSH_CONFIG_FILE
     if not ssh_config_path.exists():
         return False
     control_path = get_controlpath_for(cluster, ssh_config_path=ssh_config_path)

--- a/milatools/utils/remote_v2.py
+++ b/milatools/utils/remote_v2.py
@@ -1,24 +1,29 @@
 from __future__ import annotations
 
+import contextlib
+import dataclasses
 import getpass
-import shlex
 import shutil
 import subprocess
 import sys
 from logging import getLogger as get_logger
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 
 from paramiko import SSHConfig
 
 from milatools.cli import console
-from milatools.cli.utils import DRAC_CLUSTERS, MilatoolsUserError
+from milatools.cli.utils import (
+    DRAC_CLUSTERS,
+    SSH_CACHE_DIR,
+    SSH_CONFIG_FILE,
+    MilatoolsUserError,
+)
+from milatools.utils.local_v2 import LocalV2, run_async
 from milatools.utils.remote_v1 import Hide
+from milatools.utils.runner import Runner
 
 logger = get_logger(__name__)
-
-SSH_CONFIG_FILE = Path.home() / ".ssh" / "config"
-SSH_CACHE_DIR = Path.home() / ".cache" / "ssh"
 
 
 class UnsupportedPlatformError(MilatoolsUserError):
@@ -37,14 +42,23 @@ def raise_error_if_running_on_windows():
         )
 
 
+# note: Could potentially cache the results of this function if we wanted to, assuming
+# that the ssh config file doesn't change.
+
+
 def ssh_command(
     hostname: str,
-    control_path: Path | Literal["none"],
+    control_path: Path,
     command: str,
     control_master: Literal["yes", "no", "auto", "ask", "autoask"] = "auto",
     control_persist: int | str | Literal["yes", "no"] = "yes",
+    ssh_config_path: Path = SSH_CONFIG_FILE,
 ):
     """Returns a tuple of strings to be used as the command to be run in a subprocess.
+
+    When the path to the SSH config file is passed and exists, this will only add the
+    options which aren't already set in the SSH config, so as to avoid redundant
+    arguments to the `ssh` command.
 
     Parameters
     ----------
@@ -53,30 +67,63 @@ def ssh_command(
     command: The command to run on the remote host (kept as a string).
     control_master: See https://man.openbsd.org/ssh_config#ControlMaster
     control_persist: See https://man.openbsd.org/ssh_config#ControlPersist
+    ssh_config_path: Path to the ssh config file.
 
     Returns
     -------
     The tuple of strings to pass to `subprocess.run` or similar.
     """
-    return (
-        "ssh",
-        f"-oControlMaster={control_master}",
-        f"-oControlPersist={control_persist}",
-        f"-oControlPath={control_path}",
-        hostname,
-        command,
-    )
+    control_path = control_path.expanduser()
+    ssh_config_path = ssh_config_path.expanduser()
+    if not ssh_config_path.exists():
+        return (
+            "ssh",
+            f"-oControlMaster={control_master}",
+            f"-oControlPersist={control_persist}",
+            f"-oControlPath={control_path}",
+            hostname,
+            command,
+        )
+
+    ssh_command: list[str] = ["ssh"]
+    ssh_config_entry = SSHConfig.from_path(str(ssh_config_path)).lookup(hostname)
+    if ssh_config_entry.get("controlmaster") != control_master:
+        ssh_command.append(f"-oControlMaster={control_master}")
+    if ssh_config_entry.get("controlpersist") != control_persist:
+        ssh_command.append(f"-oControlPersist={control_persist}")
+
+    control_path_in_config = ssh_config_entry.get("controlpath")
+    if (
+        control_path_in_config is None
+        or Path(control_path_in_config).expanduser() != control_path
+    ):
+        # Only add the ControlPath arg if it is not in the config, or if it differs from
+        # the value in the config.
+        ssh_command.append(f"-oControlPath={control_path}")
+    ssh_command.append(hostname)
+    # NOTE: Not quoting the command here, `subprocess.run` does it (since shell=False).
+    ssh_command.append(command)
+    return tuple(ssh_command)
 
 
 def control_socket_is_running(host: str, control_path: Path) -> bool:
     """Check whether the control socket at the given path is running."""
+    control_path = control_path.expanduser()
     if not control_path.exists():
         return False
+
     result = subprocess.run(
-        ("ssh", "-O", "check", f"-oControlPath={control_path}", host),
-        shell=False,
-        text=True,
+        (
+            "ssh",
+            "-O",
+            "check",
+            f"-oControlPath={control_path}",
+            host,
+        ),
+        check=False,
         capture_output=True,
+        text=True,
+        shell=False,
     )
     if (
         result.returncode != 0
@@ -88,17 +135,25 @@ def control_socket_is_running(host: str, control_path: Path) -> bool:
     return True
 
 
-class RemoteV2:
+@dataclasses.dataclass(init=False)
+class RemoteV2(Runner):
     """Simpler Remote where commands are run in subprocesses sharing an SSH connection.
 
     This doesn't work on Windows, as it assumes that the SSH client has SSH multiplexing
     support (ControlMaster, ControlPath and ControlPersist).
     """
 
+    hostname: str
+    control_path: Path
+    ssh_config_path: Path
+
     def __init__(
         self,
         hostname: str,
+        *,
         control_path: Path | None = None,
+        ssh_config_path: Path = SSH_CONFIG_FILE,
+        _start_control_socket: bool = True,
     ):
         """Create an SSH connection using this control_path, creating it if necessary.
 
@@ -106,105 +161,192 @@ class RemoteV2:
         ----------
         hostname: The hostname to connect to.
         control_path: The path where the control socket will be created if it doesn't \
-            already exist. You can use `get_controlpath_for` to get this for a given
+            already exist. You can use `get_controlpath_for` to get this for a given \
             hostname.
+        ssh_config_path: Path to the ssh config file.
         """
         self.hostname = hostname
-        self.control_path = control_path or get_controlpath_for(hostname)
+        self.ssh_config_path = ssh_config_path
+        self.control_path = control_path or get_controlpath_for(
+            hostname, ssh_config_path=self.ssh_config_path
+        )
+        self.control_path = self.control_path.expanduser()
+        self.local_runner = LocalV2()
+        self._started = False
+        if _start_control_socket:
+            # Run an ssh command to start the control socket (synchronously), if needed.
+            self._start()
 
+    @staticmethod
+    async def connect(
+        hostname: str,
+        *,
+        control_path: Path | None = None,
+        ssh_config_path: Path = SSH_CONFIG_FILE,
+    ) -> RemoteV2:
+        """Async constructor.
+
+        Having an async constructor makes it possible to connect to multiple hosts
+        simultaneously with things like `asyncio.gather` (assuming that there is no
+        password prompt, in which case it is done sequentially).
+        """
+        logger.debug(f"Connecting to {hostname}...")
+        remote = RemoteV2(
+            hostname=hostname,
+            control_path=control_path,
+            ssh_config_path=ssh_config_path,
+            _start_control_socket=False,
+        )
+        await remote._start_async()
+        return remote
+
+    def run(
+        self,
+        command: str,
+        *,
+        input: str | None = None,
+        display: bool = True,
+        warn: bool = False,
+        hide: Hide = False,
+    ):
+        assert self._started
+        run_command = ssh_command(
+            hostname=self.hostname,
+            control_path=self.control_path,
+            command=command,
+            ssh_config_path=self.ssh_config_path,
+        )
+        if display:
+            # NOTE: Only display the input if it is passed.
+            if not input:
+                console.log(f"({self.hostname}) $ {command}", style="green")
+            else:
+                console.log(f"({self.hostname}) $ {command=}\n{input}", style="green")
+        # Run the ssh command with the subprocess.run function.
+        return self.local_runner.run(
+            command=run_command, input=input, display=False, warn=warn, hide=hide
+        )
+
+    async def run_async(
+        self,
+        command: str,
+        *,
+        input: str | None = None,
+        display: bool = True,
+        warn: bool = False,
+        hide: Hide = False,
+    ) -> subprocess.CompletedProcess[str]:
+        assert self._started
+        run_command = ssh_command(
+            hostname=self.hostname,
+            control_path=self.control_path,
+            command=command,
+            ssh_config_path=self.ssh_config_path,
+        )
+        if display:
+            if not input:
+                console.log(f"({self.hostname}) $ {command}", style="green")
+            else:
+                console.log(f"({self.hostname}) $ {command=}\n{input}", style="green")
+        return await self.local_runner.run_async(
+            command=run_command, input=input, display=False, warn=warn, hide=hide
+        )
+
+    def _start(self) -> None:
+        """Called by `__init__` to start the control socket if needed."""
+        if self._started:
+            return
         if not control_socket_is_running(self.hostname, self.control_path):
             logger.info(
                 f"Creating a reusable connection to the {self.hostname} cluster."
             )
             setup_connection_with_controlpath(
                 self.hostname,
-                self.control_path,
-                timeout=None,
-                display=False,
+                control_path=self.control_path,
+                ssh_config_path=self.ssh_config_path,
             )
         else:
-            logger.info(f"Reusing an existing SSH socket at {self.control_path}.")
-
+            logger.debug(f"Reusing an existing SSH socket at {self.control_path}.")
         assert control_socket_is_running(self.hostname, self.control_path)
+        self._started = True
 
-    def run(
-        self, command: str, display: bool = True, warn: bool = False, hide: Hide = False
-    ):
-        assert self.control_path.exists()
-        run_command = ssh_command(
-            hostname=self.hostname,
-            control_path=self.control_path,
-            control_master="auto",
-            control_persist="yes",
-            command=command,
-        )
-        logger.debug(f"(local) $ {shlex.join(run_command)}")
-        if display:
-            console.log(f"({self.hostname}) $ {command}", style="green")
-        result = subprocess.run(
-            run_command,
-            capture_output=True,
-            check=not warn,
-            text=True,
-            bufsize=1,  # 1 means line buffered
-        )
-        if result.stdout:
-            if hide not in [True, "out", "stdout"]:
-                print(result.stdout)
-            logger.debug(f"{result.stdout}")
-        if result.stderr:
-            if hide not in [True, "err", "stderr"]:
-                print(result.stderr)
-            logger.debug(f"{result.stderr}")
-        return result
+    async def _start_async(self) -> None:
+        """Called by `connect` to start the control socket asynchronously if needed."""
+        if self._started:
+            return
+        if not await control_socket_is_running_async(self.hostname, self.control_path):
+            logger.info(
+                f"Creating a reusable connection to the {self.hostname} cluster."
+            )
+            await setup_connection_with_controlpath_async(
+                self.hostname,
+                control_path=self.control_path,
+                ssh_config_path=self.ssh_config_path,
+            )
+        else:
+            logger.debug(f"Reusing an existing SSH socket at {self.control_path}.")
 
-    def __eq__(self, other: Any) -> bool:
-        return (
-            isinstance(other, type(self))
-            and other.hostname == self.hostname
-            and other.control_path == self.control_path
-        )
+        assert await control_socket_is_running_async(self.hostname, self.control_path)
+        self._started = True
 
-    def __repr__(self) -> str:
-        return f"{type(self).__name__}(hostname={self.hostname!r}, control_path={str(self.control_path)})"
 
-    def get_output(
-        self,
-        command: str,
-        display=False,
-        warn=False,
+async def control_socket_is_running_async(host: str, control_path: Path) -> bool:
+    """Check whether the control socket at the given path is running asynchronously."""
+    control_path = control_path.expanduser()
+    if not control_path.exists():
+        return False
+
+    result = await run_async(
+        (
+            "ssh",
+            "-O",
+            "check",
+            f"-oControlPath={control_path}",
+            host,
+        ),
+        warn=True,
         hide=True,
+    )
+    if (
+        result.returncode != 0
+        or not result.stderr
+        or not result.stderr.startswith("Master running")
     ):
-        return self.run(command, display=display, warn=warn, hide=hide).stdout.strip()
+        logger.debug(f"{control_path=} doesn't exist or isn't running: {result=}.")
+        return False
+    return True
 
 
-def is_already_logged_in(cluster: str, also_run_command_to_check: bool = False) -> bool:
+def option_dict_to_flags(options: dict[str, str]) -> list[str]:
+    return [
+        (
+            f"--{key.removeprefix('--')}={value}"
+            if value is not None
+            else f"--{key.removeprefix('--')}"
+        )
+        for key, value in options.items()
+    ]
+
+
+def is_already_logged_in(cluster: str) -> bool:
     """Checks whether we are already logged in to the given cluster.
 
     More specifically, this checks whether a reusable SSH control master is setup at the
     controlpath for the given cluster.
 
     NOTE: This function is not supported on Windows.
-
-    Parameters
-    ----------
-    cluster: Hostname of the cluster to connect to.
-    also_run_command_to_check: Whether we should also run a command over SSH to make
-        100% sure that we are logged in. In most cases this isn't necessary so we can
-        skip it, since it can take a few seconds.
     """
-    if not SSH_CONFIG_FILE.exists():
+    ssh_config_path = SSH_CONFIG_FILE
+    if not ssh_config_path.exists():
         return False
-    control_path = get_controlpath_for(cluster, ssh_config_path=SSH_CONFIG_FILE)
+    control_path = get_controlpath_for(cluster, ssh_config_path=ssh_config_path)
     if not control_path.exists():
         logger.debug(f"ControlPath at {control_path} doesn't exist. Not logged in.")
         return False
 
     if not control_socket_is_running(cluster, control_path):
         return False
-    if not also_run_command_to_check:
-        return True
-    return RemoteV2(cluster, control_path=control_path).get_output("echo OK") == "OK"
+    return True
 
 
 def get_controlpath_for(
@@ -226,33 +368,41 @@ def get_controlpath_for(
     If `ssh_cache_dir` is not set, and the `ControlPath` option doesn't apply for that
     hostname, a `RuntimeError` is raised.
     """
-    if not ssh_config_path.exists():
-        raise MilatoolsUserError(f"SSH config file doesn't exist at {ssh_config_path}.")
+    ssh_config_values: dict[str, str] = {}
 
-    ssh_config = SSHConfig.from_path(str(ssh_config_path))
-    values = ssh_config.lookup(cluster)
-    if not (control_path := values.get("controlpath")):
-        if ssh_cache_dir is None:
-            raise RuntimeError(
-                f"ControlPath isn't set in the ssh config for {cluster}, and "
-                "ssh_cache_dir isn't set."
-            )
-        logger.debug(
-            f"ControlPath isn't set for host {cluster}. Falling back to the ssh cache "
-            f"directory at {ssh_cache_dir}."
+    if ssh_config_path.exists():
+        # note: This also does the substitutions in the vars, e.g. %p -> port, etc.
+        ssh_config_values = SSHConfig.from_path(str(ssh_config_path)).lookup(cluster)
+
+    if control_path := ssh_config_values.get("controlpath"):
+        # Controlpath is set in the SSH config.
+        return Path(control_path).expanduser()
+
+    if ssh_cache_dir is None:
+        raise RuntimeError(
+            f"ControlPath isn't set in the ssh config for {cluster}, and "
+            "ssh_cache_dir isn't set."
         )
-        hostname = values.get("hostname", cluster)
-        username = values.get("user", getpass.getuser())
-        port = values.get("port", 22)
-        control_path = ssh_cache_dir / f"{username}@{hostname}:{port}"
-    return Path(control_path).expanduser()
+
+    ssh_cache_dir = ssh_cache_dir.expanduser()
+    logger.debug(
+        f"ControlPath isn't set for host {cluster}. Falling back to the ssh cache "
+        f"directory at {ssh_cache_dir}."
+    )
+    # Assume that the hostname is the same if not set.
+    hostname = ssh_config_values.get("hostname", cluster)
+    if "@" in hostname:
+        logger.debug(f"Username is already in the hostname: {hostname}")
+        return ssh_cache_dir / hostname
+    username = ssh_config_values.get("user", getpass.getuser())
+    port = int(ssh_config_values.get("port", 22))
+    return ssh_cache_dir / f"{username}@{hostname}:{port}"
 
 
 def setup_connection_with_controlpath(
     cluster: str,
     control_path: Path,
-    display: bool = True,
-    timeout: int | None = None,
+    ssh_config_path: Path = SSH_CONFIG_FILE,
 ) -> None:
     """Setup (or test) an SSH connection to this cluster using this control path.
 
@@ -262,31 +412,79 @@ def setup_connection_with_controlpath(
     ----------
     cluster: name of the cluster to connect to.
     control_path: Path to the control socket file.
-    display: Whether to display the command being run.
-    timeout: Timeout in seconds for the subprocess. Set to `None` for no timeout.
+    ssh_config_path: Path to the ssh config file.
 
     Raises
     ------
-    subprocess.TimeoutExpired
-        If `timeout` was passed and the subprocess times out.
     subprocess.CalledProcessError
         If the subprocess call raised an error.
     RuntimeError
         If the control path doesn't exist after the first connection, or if we didn't
         receive the output we expected from running the command.
     """
+    # note: Trying to reduce the code duplication between sync/async versions of this
+    # function as much as possible, but this isn't quite there yet :(.
     raise_error_if_running_on_windows()
+    setup_ssh_control_socket_command = _get_setup_ssh_control_socket_command(
+        cluster=cluster, control_path=control_path, ssh_config_path=ssh_config_path
+    )
+    with _catch_setup_ssh_control_socket_errors(cluster=cluster):
+        first_connection_output = LocalV2().get_output(
+            command=setup_ssh_control_socket_command,
+            display=False,
+            hide="out",
+            warn=False,
+        )
+    _raise_if_controlsocket_not_setup(cluster, control_path, first_connection_output)
+    _log_successful_setup(cluster, control_path)
 
+
+async def setup_connection_with_controlpath_async(
+    cluster: str,
+    control_path: Path,
+    ssh_config_path: Path = SSH_CONFIG_FILE,
+) -> None:
+    """Sets up the SSH control socket asynchronously.
+
+    See the sync version of this function for more info. Only a single line differs
+    between the two.
+    """
+    raise_error_if_running_on_windows()
+    setup_ssh_control_socket_command = _get_setup_ssh_control_socket_command(
+        cluster=cluster, control_path=control_path, ssh_config_path=ssh_config_path
+    )
+    with _catch_setup_ssh_control_socket_errors(cluster=cluster):
+        first_connection_output = await LocalV2().get_output_async(  # only change
+            command=setup_ssh_control_socket_command,
+            display=False,
+            hide="out",
+            warn=False,
+        )
+    _raise_if_controlsocket_not_setup(cluster, control_path, first_connection_output)
+    _log_successful_setup(cluster, control_path)
+
+
+def _log_successful_setup(cluster: str, control_path: Path):
+    logger.info(
+        f"Success: Shareable SSH Connection to {cluster} is setup at {control_path=}"
+    )
+
+
+def _get_setup_ssh_control_socket_command(
+    cluster: str, control_path: Path, ssh_config_path: Path = SSH_CONFIG_FILE
+):
+    control_path = control_path.expanduser()
     if not control_path.exists():
         control_path.parent.mkdir(parents=True, exist_ok=True)
 
     command = "echo OK"
-    first_command_args = ssh_command(
+    ssh_command_args = ssh_command(
         hostname=cluster,
         control_path=control_path,
         control_master="auto",
         control_persist="yes",
         command=command,
+        ssh_config_path=ssh_config_path,
     )
     if cluster in DRAC_CLUSTERS:
         console.log(
@@ -302,16 +500,16 @@ def setup_connection_with_controlpath(
             #     style="yellow",
             # )
             # Enter 1 with `sshpass` to go straight to the prompt on the phone.
-            first_command_args = (
+            ssh_command_args = (
                 "sshpass",
                 "-P",
                 "Duo two-factor login",
                 "-p",
                 "1",
-                *first_command_args,
+                *ssh_command_args,
             )
         else:
-            logger.debug(
+            logger.warning(
                 f"`sshpass` is not installed. If 2FA is setup on {cluster}, you might "
                 "be asked to press 1 or enter a 2fa passcode."
             )
@@ -322,30 +520,26 @@ def setup_connection_with_controlpath(
         pass
 
     logger.info(f"Making the first connection to {cluster}...")
-    logger.debug(f"(local) $ {first_command_args}")
-    if display:
-        console.log(f"({cluster}) $ {command}", style="green")
+    return ssh_command_args
+
+
+@contextlib.contextmanager
+def _catch_setup_ssh_control_socket_errors(cluster: str):
     try:
-        first_connection_result = subprocess.run(
-            first_command_args,
-            shell=False,
-            text=True,
-            bufsize=1,  # line buffered
-            timeout=timeout,
-            capture_output=True,
-            check=True,
-        )
-        first_connection_output = first_connection_result.stdout
-    except subprocess.TimeoutExpired as err:
+        yield
+    except subprocess.TimeoutExpired:
         console.log(
             f"Timeout while setting up a reusable SSH connection to cluster {cluster}!"
         )
-        raise err
-    except subprocess.CalledProcessError as err:
-        console.log(
-            f"Unable to setup a reusable SSH connection to cluster {cluster}!", err
-        )
-        raise err
+        raise
+    except subprocess.CalledProcessError:
+        console.log(f"Unable to setup a reusable SSH connection to cluster {cluster}!")
+        raise
+
+
+def _raise_if_controlsocket_not_setup(
+    cluster: str, control_path: Path, first_connection_output: str
+):
     if "OK" not in first_connection_output:
         raise RuntimeError(
             f"Did not receive the expected output ('OK') from {cluster}: "
@@ -356,6 +550,3 @@ def setup_connection_with_controlpath(
             f"Expected a socket file to be created at {control_path} after the first "
             f"connection!"
         )
-    logger.info(
-        f"Success: Shareable SSH Connection to {cluster} is setup at {control_path=}"
-    )

--- a/milatools/utils/runner.py
+++ b/milatools/utils/runner.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import subprocess
+from abc import ABC, abstractmethod
+
+from milatools.utils.remote_v1 import Hide
+
+
+class Runner(ABC):
+    """ABC for a Runner that runs commands on a (local or remote) machine."""
+
+    hostname: str
+    """Hostname of the machine that commands are ultimately being run on."""
+
+    @abstractmethod
+    def run(
+        self,
+        command: str,
+        *,
+        input: str | None = None,
+        display: bool = True,
+        warn: bool = False,
+        hide: Hide = False,
+    ) -> subprocess.CompletedProcess[str]:
+        """Runs the given command on the remote and returns the result.
+
+        This executes the command in an ssh subprocess, which, thanks to the
+        ControlMaster/ControlPath/ControlPersist options, will reuse the existing
+        connection to the remote.
+
+        Parameters
+        ----------
+        command: The command to run.
+        input: Input to pass to the program (argument to `subprocess.run`).
+        display: Display the command on the console before it is run.
+        warn: If `true` and an exception occurs, warn instead of raising the exception.
+        hide: Controls the printing of the subprocess' stdout and stderr.
+
+        Returns
+        -------
+        A `subprocess.CompletedProcess` object with the output of the subprocess.
+        """
+        # note: Could also have a default implementation just waits on the async method:
+        # return asyncio.get_event_loop().run_until_complete(
+        #     self.run_async(command, input=input, display=display, warn=warn, hide=hide)
+        # )
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def run_async(
+        self,
+        command: str,
+        *,
+        input: str | None = None,
+        display: bool = True,
+        warn: bool = False,
+        hide: Hide = False,
+    ) -> subprocess.CompletedProcess[str]:
+        """Runs the given command asynchronously and returns the result.
+
+        This executes the command over ssh in an asyncio subprocess, which reuses the
+        existing connection to the remote.
+
+        Parameters
+        ----------
+        command: The command to run.
+        input: Input to pass to the program (as if it was the 'input' argument to \
+               `asyncio.subprocess.Process.communicate`).
+        display: Display the command on the console before it is run.
+        warn: If `true` and an exception occurs, warn instead of raising the exception.
+        hide: Controls the printing of the subprocess' stdout and stderr.
+
+        Returns
+        -------
+        A `subprocess.CompletedProcess` object with the output of the subprocess.
+        """
+        raise NotImplementedError()
+
+    def get_output(
+        self,
+        command: str,
+        *,
+        display: bool = False,
+        warn: bool = False,
+        hide: Hide = True,
+    ) -> str:
+        """Runs the command and returns the stripped output string."""
+        return self.run(command, display=display, warn=warn, hide=hide).stdout.strip()
+
+    async def get_output_async(
+        self,
+        command: str,
+        *,
+        display: bool = False,
+        warn: bool = False,
+        hide: Hide = True,
+    ) -> str:
+        """Runs the command asynchronously and returns the stripped output string."""
+        return (
+            await self.run_async(command, display=display, warn=warn, hide=hide)
+        ).stdout.strip()

--- a/poetry.lock
+++ b/poetry.lock
@@ -81,36 +81,33 @@ typecheck = ["mypy"]
 
 [[package]]
 name = "black"
-version = "23.3.0"
+version = "24.4.2"
 description = "The uncompromising code formatter."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "black-23.3.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915"},
-    {file = "black-23.3.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:67de8d0c209eb5b330cce2469503de11bca4085880d62f1628bd9972cc3366b9"},
-    {file = "black-23.3.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:7c3eb7cea23904399866c55826b31c1f55bbcd3890ce22ff70466b907b6775c2"},
-    {file = "black-23.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32daa9783106c28815d05b724238e30718f34155653d4d6e125dc7daec8e260c"},
-    {file = "black-23.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:35d1381d7a22cc5b2be2f72c7dfdae4072a3336060635718cc7e1ede24221d6c"},
-    {file = "black-23.3.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:a8a968125d0a6a404842fa1bf0b349a568634f856aa08ffaff40ae0dfa52e7c6"},
-    {file = "black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b"},
-    {file = "black-23.3.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:a6f6886c9869d4daae2d1715ce34a19bbc4b95006d20ed785ca00fa03cba312d"},
-    {file = "black-23.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f3c333ea1dd6771b2d3777482429864f8e258899f6ff05826c3a4fcc5ce3f70"},
-    {file = "black-23.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:11c410f71b876f961d1de77b9699ad19f939094c3a677323f43d7a29855fe326"},
-    {file = "black-23.3.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:1d06691f1eb8de91cd1b322f21e3bfc9efe0c7ca1f0e1eb1db44ea367dff656b"},
-    {file = "black-23.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50cb33cac881766a5cd9913e10ff75b1e8eb71babf4c7104f2e9c52da1fb7de2"},
-    {file = "black-23.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e114420bf26b90d4b9daa597351337762b63039752bdf72bf361364c1aa05925"},
-    {file = "black-23.3.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:48f9d345675bb7fbc3dd85821b12487e1b9a75242028adad0333ce36ed2a6d27"},
-    {file = "black-23.3.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:714290490c18fb0126baa0fca0a54ee795f7502b44177e1ce7624ba1c00f2331"},
-    {file = "black-23.3.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:064101748afa12ad2291c2b91c960be28b817c0c7eaa35bec09cc63aa56493c5"},
-    {file = "black-23.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:562bd3a70495facf56814293149e51aa1be9931567474993c7942ff7d3533961"},
-    {file = "black-23.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:e198cf27888ad6f4ff331ca1c48ffc038848ea9f031a3b40ba36aced7e22f2c8"},
-    {file = "black-23.3.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:3238f2aacf827d18d26db07524e44741233ae09a584273aa059066d644ca7b30"},
-    {file = "black-23.3.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"},
-    {file = "black-23.3.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:92c543f6854c28a3c7f39f4d9b7694f9a6eb9d3c5e2ece488c327b6e7ea9b266"},
-    {file = "black-23.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a150542a204124ed00683f0db1f5cf1c2aaaa9cc3495b7a3b5976fb136090ab"},
-    {file = "black-23.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:6b39abdfb402002b8a7d030ccc85cf5afff64ee90fa4c5aebc531e3ad0175ddb"},
-    {file = "black-23.3.0-py3-none-any.whl", hash = "sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4"},
-    {file = "black-23.3.0.tar.gz", hash = "sha256:1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940"},
+    {file = "black-24.4.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dd1b5a14e417189db4c7b64a6540f31730713d173f0b63e55fabd52d61d8fdce"},
+    {file = "black-24.4.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e537d281831ad0e71007dcdcbe50a71470b978c453fa41ce77186bbe0ed6021"},
+    {file = "black-24.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaea3008c281f1038edb473c1aa8ed8143a5535ff18f978a318f10302b254063"},
+    {file = "black-24.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:7768a0dbf16a39aa5e9a3ded568bb545c8c2727396d063bbaf847df05b08cd96"},
+    {file = "black-24.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:257d724c2c9b1660f353b36c802ccece186a30accc7742c176d29c146df6e474"},
+    {file = "black-24.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bdde6f877a18f24844e381d45e9947a49e97933573ac9d4345399be37621e26c"},
+    {file = "black-24.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e151054aa00bad1f4e1f04919542885f89f5f7d086b8a59e5000e6c616896ffb"},
+    {file = "black-24.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:7e122b1c4fb252fd85df3ca93578732b4749d9be076593076ef4d07a0233c3e1"},
+    {file = "black-24.4.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:accf49e151c8ed2c0cdc528691838afd217c50412534e876a19270fea1e28e2d"},
+    {file = "black-24.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:88c57dc656038f1ab9f92b3eb5335ee9b021412feaa46330d5eba4e51fe49b04"},
+    {file = "black-24.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be8bef99eb46d5021bf053114442914baeb3649a89dc5f3a555c88737e5e98fc"},
+    {file = "black-24.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:415e686e87dbbe6f4cd5ef0fbf764af7b89f9057b97c908742b6008cc554b9c0"},
+    {file = "black-24.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bf10f7310db693bb62692609b397e8d67257c55f949abde4c67f9cc574492cc7"},
+    {file = "black-24.4.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:98e123f1d5cfd42f886624d84464f7756f60ff6eab89ae845210631714f6db94"},
+    {file = "black-24.4.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48a85f2cb5e6799a9ef05347b476cce6c182d6c71ee36925a6c194d074336ef8"},
+    {file = "black-24.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:b1530ae42e9d6d5b670a34db49a94115a64596bc77710b1d05e9801e62ca0a7c"},
+    {file = "black-24.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:37aae07b029fa0174d39daf02748b379399b909652a806e5708199bd93899da1"},
+    {file = "black-24.4.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:da33a1a5e49c4122ccdfd56cd021ff1ebc4a1ec4e2d01594fef9b6f267a9e741"},
+    {file = "black-24.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef703f83fc32e131e9bcc0a5094cfe85599e7109f896fe8bc96cc402f3eb4b6e"},
+    {file = "black-24.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:b9176b9832e84308818a99a561e90aa479e73c523b3f77afd07913380ae2eab7"},
+    {file = "black-24.4.2-py3-none-any.whl", hash = "sha256:d36ed1124bb81b32f8614555b34cc4259c3fbc7eec17870e8ff8ded335b58d8c"},
+    {file = "black-24.4.2.tar.gz", hash = "sha256:c872b53057f000085da66a19c55d68f6f8ddcac2642392ad3a355878406fbd4d"},
 ]
 
 [package.dependencies]
@@ -120,11 +117,11 @@ packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
+d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
@@ -146,86 +143,74 @@ wcwidth = ">=0.1.4"
 
 [[package]]
 name = "certifi"
-version = "2023.11.17"
+version = "2024.2.2"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2023.11.17-py3-none-any.whl", hash = "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"},
-    {file = "certifi-2023.11.17.tar.gz", hash = "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"},
+    {file = "certifi-2024.2.2-py3-none-any.whl", hash = "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"},
+    {file = "certifi-2024.2.2.tar.gz", hash = "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"},
 ]
 
 [[package]]
 name = "cffi"
-version = "1.15.1"
+version = "1.16.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
-python-versions = "*"
+python-versions = ">=3.8"
 files = [
-    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
-    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
-    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
-    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
-    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
-    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
-    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
-    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
-    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
-    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
-    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
-    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
-    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
-    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
-    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
-    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
-    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
-    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
-    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
-    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
-    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
-    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
-    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
-    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
-    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
-    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
-    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
-    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
-    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
-    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
-    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
-    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
-    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
-    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
-    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
-    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
-    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
-    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
-    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
-    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
-    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
-    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
-    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
-    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
-    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
-    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
-    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
-    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
-    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
-    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
-    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
-    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
-    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
-    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
-    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
-    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
-    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
-    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
-    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
-    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
-    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
-    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
-    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
-    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
+    {file = "cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088"},
+    {file = "cffi-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ac0f5edd2360eea2f1daa9e26a41db02dd4b0451b48f7c318e217ee092a213e9"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e61e3e4fa664a8588aa25c883eab612a188c725755afff6289454d6362b9673"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a72e8961a86d19bdb45851d8f1f08b041ea37d2bd8d4fd19903bc3083d80c896"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b50bf3f55561dac5438f8e70bfcdfd74543fd60df5fa5f62d94e5867deca684"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7651c50c8c5ef7bdb41108b7b8c5a83013bfaa8a935590c5d74627c047a583c7"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4108df7fe9b707191e55f33efbcb2d81928e10cea45527879a4749cbe472614"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:32c68ef735dbe5857c810328cb2481e24722a59a2003018885514d4c09af9743"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:673739cb539f8cdaa07d92d02efa93c9ccf87e345b9a0b556e3ecc666718468d"},
+    {file = "cffi-1.16.0-cp310-cp310-win32.whl", hash = "sha256:9f90389693731ff1f659e55c7d1640e2ec43ff725cc61b04b2f9c6d8d017df6a"},
+    {file = "cffi-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:e6024675e67af929088fda399b2094574609396b1decb609c55fa58b028a32a1"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee07e47c12890ef248766a6e55bd38ebfb2bb8edd4142d56db91b21ea68b7627"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8a9d3ebe49f084ad71f9269834ceccbf398253c9fac910c4fd7053ff1386936"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e70f54f1796669ef691ca07d046cd81a29cb4deb1e5f942003f401c0c4a2695d"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5bf44d66cdf9e893637896c7faa22298baebcd18d1ddb6d2626a6e39793a1d56"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c6a164aa47843fb1b01e941d385aab7215563bb8816d80ff3a363a9f8448a8dc"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e09f3ff613345df5e8c3667da1d918f9149bd623cd9070c983c013792a9a62eb"},
+    {file = "cffi-1.16.0-cp311-cp311-win32.whl", hash = "sha256:2c56b361916f390cd758a57f2e16233eb4f64bcbeee88a4881ea90fca14dc6ab"},
+    {file = "cffi-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:fa3a0128b152627161ce47201262d3140edb5a5c3da88d73a1b790a959126956"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:68e7c44931cc171c54ccb702482e9fc723192e88d25a0e133edd7aff8fcd1f6e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd808f9c129ba2beda4cfc53bde801e5bcf9d6e0f22f095e45327c038bfe68e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88e2b3c14bdb32e440be531ade29d3c50a1a59cd4e51b1dd8b0865c54ea5d2e2"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcc8eb6d5902bb1cf6dc4f187ee3ea80a1eba0a89aba40a5cb20a5087d961357"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7be2d771cdba2942e13215c4e340bfd76398e9227ad10402a8767ab1865d2e6"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e715596e683d2ce000574bae5d07bd522c781a822866c20495e52520564f0969"},
+    {file = "cffi-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520"},
+    {file = "cffi-1.16.0-cp312-cp312-win32.whl", hash = "sha256:b2ca4e77f9f47c55c194982e10f058db063937845bb2b7a86c84a6cfe0aefa8b"},
+    {file = "cffi-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:68678abf380b42ce21a5f2abde8efee05c114c2fdb2e9eef2efdb0257fba1235"},
+    {file = "cffi-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a09582f178759ee8128d9270cd1344154fd473bb77d94ce0aeb2a93ebf0feaf0"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e760191dd42581e023a68b758769e2da259b5d52e3103c6060ddc02c9edb8d7b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80876338e19c951fdfed6198e70bc88f1c9758b94578d5a7c4c91a87af3cf31c"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a6a14b17d7e17fa0d207ac08642c8820f84f25ce17a442fd15e27ea18d67c59b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6602bc8dc6f3a9e02b6c22c4fc1e47aa50f8f8e6d3f78a5e16ac33ef5fefa324"},
+    {file = "cffi-1.16.0-cp38-cp38-win32.whl", hash = "sha256:131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a"},
+    {file = "cffi-1.16.0-cp38-cp38-win_amd64.whl", hash = "sha256:31d13b0f99e0836b7ff893d37af07366ebc90b678b6664c955b54561fc36ef36"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc9b18bf40cc75f66f40a7379f6a9513244fe33c0e8aa72e2d56b0196a7ef872"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b86851a328eedc692acf81fb05444bdf1891747c25af7529e39ddafaf68a4f3f"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c0f31130ebc2d37cdd8e44605fb5fa7ad59049298b3f745c74fa74c62fbfcfc4"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:748dcd1e3d3d7cd5443ef03ce8685043294ad6bd7c02a38d1bd367cfd968e000"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe"},
+    {file = "cffi-1.16.0-cp39-cp39-win32.whl", hash = "sha256:ed86a35631f7bfbb28e108dd96773b9d5a6ce4811cf6ea468bb6a359b256b1e4"},
+    {file = "cffi-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:3686dffb02459559c74dd3d81748269ffb0eb027c39a6fc99502de37d501faa8"},
+    {file = "cffi-1.16.0.tar.gz", hash = "sha256:bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0"},
 ]
 
 [package.dependencies]
@@ -424,47 +409,56 @@ toml = ["toml"]
 
 [[package]]
 name = "cryptography"
-version = "41.0.7"
+version = "42.0.5"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "cryptography-41.0.7-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:3c78451b78313fa81607fa1b3f1ae0a5ddd8014c38a02d9db0616133987b9cdf"},
-    {file = "cryptography-41.0.7-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:928258ba5d6f8ae644e764d0f996d61a8777559f72dfeb2eea7e2fe0ad6e782d"},
-    {file = "cryptography-41.0.7-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a1b41bc97f1ad230a41657d9155113c7521953869ae57ac39ac7f1bb471469a"},
-    {file = "cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:841df4caa01008bad253bce2a6f7b47f86dc9f08df4b433c404def869f590a15"},
-    {file = "cryptography-41.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5429ec739a29df2e29e15d082f1d9ad683701f0ec7709ca479b3ff2708dae65a"},
-    {file = "cryptography-41.0.7-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:43f2552a2378b44869fe8827aa19e69512e3245a219104438692385b0ee119d1"},
-    {file = "cryptography-41.0.7-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:af03b32695b24d85a75d40e1ba39ffe7db7ffcb099fe507b39fd41a565f1b157"},
-    {file = "cryptography-41.0.7-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:49f0805fc0b2ac8d4882dd52f4a3b935b210935d500b6b805f321addc8177406"},
-    {file = "cryptography-41.0.7-cp37-abi3-win32.whl", hash = "sha256:f983596065a18a2183e7f79ab3fd4c475205b839e02cbc0efbbf9666c4b3083d"},
-    {file = "cryptography-41.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:90452ba79b8788fa380dfb587cca692976ef4e757b194b093d845e8d99f612f2"},
-    {file = "cryptography-41.0.7-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:079b85658ea2f59c4f43b70f8119a52414cdb7be34da5d019a77bf96d473b960"},
-    {file = "cryptography-41.0.7-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:b640981bf64a3e978a56167594a0e97db71c89a479da8e175d8bb5be5178c003"},
-    {file = "cryptography-41.0.7-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:e3114da6d7f95d2dee7d3f4eec16dacff819740bbab931aff8648cb13c5ff5e7"},
-    {file = "cryptography-41.0.7-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d5ec85080cce7b0513cfd233914eb8b7bbd0633f1d1703aa28d1dd5a72f678ec"},
-    {file = "cryptography-41.0.7-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7a698cb1dac82c35fcf8fe3417a3aaba97de16a01ac914b89a0889d364d2f6be"},
-    {file = "cryptography-41.0.7-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:37a138589b12069efb424220bf78eac59ca68b95696fc622b6ccc1c0a197204a"},
-    {file = "cryptography-41.0.7-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:68a2dec79deebc5d26d617bfdf6e8aab065a4f34934b22d3b5010df3ba36612c"},
-    {file = "cryptography-41.0.7-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:09616eeaef406f99046553b8a40fbf8b1e70795a91885ba4c96a70793de5504a"},
-    {file = "cryptography-41.0.7-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:48a0476626da912a44cc078f9893f292f0b3e4c739caf289268168d8f4702a39"},
-    {file = "cryptography-41.0.7-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c7f3201ec47d5207841402594f1d7950879ef890c0c495052fa62f58283fde1a"},
-    {file = "cryptography-41.0.7-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c5ca78485a255e03c32b513f8c2bc39fedb7f5c5f8535545bdc223a03b24f248"},
-    {file = "cryptography-41.0.7-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d6c391c021ab1f7a82da5d8d0b3cee2f4b2c455ec86c8aebbc84837a631ff309"},
-    {file = "cryptography-41.0.7.tar.gz", hash = "sha256:13f93ce9bea8016c253b34afc6bd6a75993e5c40672ed5405a9c832f0d4a00bc"},
+    {file = "cryptography-42.0.5-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:a30596bae9403a342c978fb47d9b0ee277699fa53bbafad14706af51fe543d16"},
+    {file = "cryptography-42.0.5-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b7ffe927ee6531c78f81aa17e684e2ff617daeba7f189f911065b2ea2d526dec"},
+    {file = "cryptography-42.0.5-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2424ff4c4ac7f6b8177b53c17ed5d8fa74ae5955656867f5a8affaca36a27abb"},
+    {file = "cryptography-42.0.5-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:329906dcc7b20ff3cad13c069a78124ed8247adcac44b10bea1130e36caae0b4"},
+    {file = "cryptography-42.0.5-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b03c2ae5d2f0fc05f9a2c0c997e1bc18c8229f392234e8a0194f202169ccd278"},
+    {file = "cryptography-42.0.5-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7"},
+    {file = "cryptography-42.0.5-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:0270572b8bd2c833c3981724b8ee9747b3ec96f699a9665470018594301439ee"},
+    {file = "cryptography-42.0.5-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:b8cac287fafc4ad485b8a9b67d0ee80c66bf3574f655d3b97ef2e1082360faf1"},
+    {file = "cryptography-42.0.5-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:16a48c23a62a2f4a285699dba2e4ff2d1cff3115b9df052cdd976a18856d8e3d"},
+    {file = "cryptography-42.0.5-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2bce03af1ce5a5567ab89bd90d11e7bbdff56b8af3acbbec1faded8f44cb06da"},
+    {file = "cryptography-42.0.5-cp37-abi3-win32.whl", hash = "sha256:b6cd2203306b63e41acdf39aa93b86fb566049aeb6dc489b70e34bcd07adca74"},
+    {file = "cryptography-42.0.5-cp37-abi3-win_amd64.whl", hash = "sha256:98d8dc6d012b82287f2c3d26ce1d2dd130ec200c8679b6213b3c73c08b2b7940"},
+    {file = "cryptography-42.0.5-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:5e6275c09d2badf57aea3afa80d975444f4be8d3bc58f7f80d2a484c6f9485c8"},
+    {file = "cryptography-42.0.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4985a790f921508f36f81831817cbc03b102d643b5fcb81cd33df3fa291a1a1"},
+    {file = "cryptography-42.0.5-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7cde5f38e614f55e28d831754e8a3bacf9ace5d1566235e39d91b35502d6936e"},
+    {file = "cryptography-42.0.5-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7367d7b2eca6513681127ebad53b2582911d1736dc2ffc19f2c3ae49997496bc"},
+    {file = "cryptography-42.0.5-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cd2030f6650c089aeb304cf093f3244d34745ce0cfcc39f20c6fbfe030102e2a"},
+    {file = "cryptography-42.0.5-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a2913c5375154b6ef2e91c10b5720ea6e21007412f6437504ffea2109b5a33d7"},
+    {file = "cryptography-42.0.5-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:c41fb5e6a5fe9ebcd58ca3abfeb51dffb5d83d6775405305bfa8715b76521922"},
+    {file = "cryptography-42.0.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3eaafe47ec0d0ffcc9349e1708be2aaea4c6dd4978d76bf6eb0cb2c13636c6fc"},
+    {file = "cryptography-42.0.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b95b98b0d2af784078fa69f637135e3c317091b615cd0905f8b8a087e86fa30"},
+    {file = "cryptography-42.0.5-cp39-abi3-win32.whl", hash = "sha256:1f71c10d1e88467126f0efd484bd44bca5e14c664ec2ede64c32f20875c0d413"},
+    {file = "cryptography-42.0.5-cp39-abi3-win_amd64.whl", hash = "sha256:a011a644f6d7d03736214d38832e030d8268bcff4a41f728e6030325fea3e400"},
+    {file = "cryptography-42.0.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9481ffe3cf013b71b2428b905c4f7a9a4f76ec03065b05ff499bb5682a8d9ad8"},
+    {file = "cryptography-42.0.5-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:ba334e6e4b1d92442b75ddacc615c5476d4ad55cc29b15d590cc6b86efa487e2"},
+    {file = "cryptography-42.0.5-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:ba3e4a42397c25b7ff88cdec6e2a16c2be18720f317506ee25210f6d31925f9c"},
+    {file = "cryptography-42.0.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:111a0d8553afcf8eb02a4fea6ca4f59d48ddb34497aa8706a6cf536f1a5ec576"},
+    {file = "cryptography-42.0.5-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:cd65d75953847815962c84a4654a84850b2bb4aed3f26fadcc1c13892e1e29f6"},
+    {file = "cryptography-42.0.5-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:e807b3188f9eb0eaa7bbb579b462c5ace579f1cedb28107ce8b48a9f7ad3679e"},
+    {file = "cryptography-42.0.5-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f12764b8fffc7a123f641d7d049d382b73f96a34117e0b637b80643169cec8ac"},
+    {file = "cryptography-42.0.5-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:37dd623507659e08be98eec89323469e8c7b4c1407c85112634ae3dbdb926fdd"},
+    {file = "cryptography-42.0.5.tar.gz", hash = "sha256:6fe07eec95dfd477eb9530aef5bead34fec819b3aaf6c5bd6d20565da607bfe1"},
 ]
 
 [package.dependencies]
-cffi = ">=1.12"
+cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
 
 [package.extras]
 docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
-docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
+docstest = ["pyenchant (>=1.6.11)", "readme-renderer", "sphinxcontrib-spelling (>=4.0.1)"]
 nox = ["nox"]
-pep8test = ["black", "check-sdist", "mypy", "ruff"]
+pep8test = ["check-sdist", "click", "mypy", "ruff"]
 sdist = ["build"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test = ["certifi", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -508,13 +502,13 @@ files = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.2.0"
+version = "1.2.1"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"},
-    {file = "exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"},
+    {file = "exceptiongroup-1.2.1-py3-none-any.whl", hash = "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad"},
+    {file = "exceptiongroup-1.2.1.tar.gz", hash = "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"},
 ]
 
 [package.extras]
@@ -542,29 +536,29 @@ pytest = ["pytest (>=7)"]
 
 [[package]]
 name = "flake8"
-version = "6.1.0"
+version = "7.0.0"
 description = "the modular source code checker: pep8 pyflakes and co"
 optional = false
 python-versions = ">=3.8.1"
 files = [
-    {file = "flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"},
-    {file = "flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23"},
+    {file = "flake8-7.0.0-py2.py3-none-any.whl", hash = "sha256:a6dfbb75e03252917f2473ea9653f7cd799c3064e54d4c8140044c5c065f53c3"},
+    {file = "flake8-7.0.0.tar.gz", hash = "sha256:33f96621059e65eec474169085dc92bf26e7b2d47366b70be2f67ab80dc25132"},
 ]
 
 [package.dependencies]
 mccabe = ">=0.7.0,<0.8.0"
 pycodestyle = ">=2.11.0,<2.12.0"
-pyflakes = ">=3.1.0,<3.2.0"
+pyflakes = ">=3.2.0,<3.3.0"
 
 [[package]]
 name = "idna"
-version = "3.6"
+version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"},
-    {file = "idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"},
+    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
+    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
 ]
 
 [[package]]
@@ -580,22 +574,22 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.7.0"
+version = "7.1.0"
 description = "Read metadata from Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5"},
-    {file = "importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4"},
+    {file = "importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570"},
+    {file = "importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2"},
 ]
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -621,13 +615,13 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.2"
+version = "3.1.3"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
-    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
+    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
 ]
 
 [package.dependencies]
@@ -652,13 +646,13 @@ ansicon = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "markdown-it-py"
-version = "2.2.0"
+version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "markdown-it-py-2.2.0.tar.gz", hash = "sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1"},
-    {file = "markdown_it_py-2.2.0-py3-none-any.whl", hash = "sha256:5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30"},
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
 ]
 
 [package.dependencies]
@@ -671,76 +665,76 @@ compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0
 linkify = ["linkify-it-py (>=1,<3)"]
 plugins = ["mdit-py-plugins"]
 profiling = ["gprof2dot"]
-rtd = ["attrs", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
 name = "markupsafe"
-version = "2.1.3"
+version = "2.1.5"
 description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-win32.whl", hash = "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-win_amd64.whl", hash = "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-win32.whl", hash = "sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-win_amd64.whl", hash = "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-win32.whl", hash = "sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-win_amd64.whl", hash = "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-win32.whl", hash = "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba"},
-    {file = "MarkupSafe-2.1.3.tar.gz", hash = "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-win32.whl", hash = "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-win32.whl", hash = "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-win32.whl", hash = "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb"},
+    {file = "MarkupSafe-2.1.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c8b29db45f8fe46ad280a7294f5c3ec36dbac9491f2d1c17345be8e69cc5928f"},
+    {file = "MarkupSafe-2.1.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec6a563cff360b50eed26f13adc43e61bc0c04d94b8be985e6fb24b81f6dcfdf"},
+    {file = "MarkupSafe-2.1.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a549b9c31bec33820e885335b451286e2969a2d9e24879f83fe904a5ce59d70a"},
+    {file = "MarkupSafe-2.1.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4f11aa001c540f62c6166c7726f71f7573b52c68c31f014c25cc7901deea0b52"},
+    {file = "MarkupSafe-2.1.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7b2e5a267c855eea6b4283940daa6e88a285f5f2a67f2220203786dfa59b37e9"},
+    {file = "MarkupSafe-2.1.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:2d2d793e36e230fd32babe143b04cec8a8b3eb8a3122d2aceb4a371e6b09b8df"},
+    {file = "MarkupSafe-2.1.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ce409136744f6521e39fd8e2a24c53fa18ad67aa5bc7c2cf83645cce5b5c4e50"},
+    {file = "MarkupSafe-2.1.5-cp37-cp37m-win32.whl", hash = "sha256:4096e9de5c6fdf43fb4f04c26fb114f61ef0bf2e5604b6ee3019d51b69e8c371"},
+    {file = "MarkupSafe-2.1.5-cp37-cp37m-win_amd64.whl", hash = "sha256:4275d846e41ecefa46e2015117a9f491e57a71ddd59bbead77e904dc02b1bed2"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-win32.whl", hash = "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-win_amd64.whl", hash = "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-win32.whl", hash = "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5"},
+    {file = "MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"},
 ]
 
 [[package]]
@@ -778,24 +772,24 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "23.2"
+version = "24.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
-    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
+    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
 ]
 
 [[package]]
 name = "paramiko"
-version = "3.3.1"
+version = "3.4.0"
 description = "SSH2 protocol library"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "paramiko-3.3.1-py3-none-any.whl", hash = "sha256:b7bc5340a43de4287bbe22fe6de728aa2c22468b2a849615498dd944c2f275eb"},
-    {file = "paramiko-3.3.1.tar.gz", hash = "sha256:6a3777a961ac86dbef375c5f5b8d50014a1a96d0fd7f054a43bc880134b0ff77"},
+    {file = "paramiko-3.4.0-py3-none-any.whl", hash = "sha256:43f0b51115a896f9c00f59618023484cb3a14b98bbceab43394a39c6739b7ee7"},
+    {file = "paramiko-3.4.0.tar.gz", hash = "sha256:aac08f26a31dc4dffd92821527d1682d99d52f9ef6851968114a8728f3c274d3"},
 ]
 
 [package.dependencies]
@@ -810,39 +804,40 @@ invoke = ["invoke (>=2.0)"]
 
 [[package]]
 name = "pathspec"
-version = "0.11.2"
+version = "0.12.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
-    {file = "pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
+    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
+    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
 ]
 
 [[package]]
 name = "platformdirs"
-version = "4.0.0"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+version = "4.2.1"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.0.0-py3-none-any.whl", hash = "sha256:118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b"},
-    {file = "platformdirs-4.0.0.tar.gz", hash = "sha256:cb633b2bcf10c51af60beb0ab06d2f1d69064b43abf4c185ca6b28865f3f9731"},
+    {file = "platformdirs-4.2.1-py3-none-any.whl", hash = "sha256:17d5a1161b3fd67b390023cb2d3b026bbd40abde6fdb052dfbd3a29c3ba22ee1"},
+    {file = "platformdirs-4.2.1.tar.gz", hash = "sha256:031cd18d4ec63ec53e82dceaac0417d218a6863f7745dfcc9efe7793b7039bdf"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
+docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
+type = ["mypy (>=1.8)"]
 
 [[package]]
 name = "pluggy"
-version = "1.2.0"
+version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
-    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
 ]
 
 [package.extras]
@@ -876,24 +871,24 @@ files = [
 
 [[package]]
 name = "pycparser"
-version = "2.21"
+version = "2.22"
 description = "C parser in Python"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.8"
 files = [
-    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
-    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
 
 [[package]]
 name = "pyflakes"
-version = "3.1.0"
+version = "3.2.0"
 description = "passive checker of Python programs"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774"},
-    {file = "pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"},
+    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
+    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
 ]
 
 [[package]]
@@ -939,13 +934,13 @@ tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
 name = "pytest"
-version = "7.4.3"
+version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
-    {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
+    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
+    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
 ]
 
 [package.dependencies]
@@ -958,6 +953,24 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.23.6"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-asyncio-0.23.6.tar.gz", hash = "sha256:ffe523a89c1c222598c76856e76852b787504ddb72dd5d9b6617ffa8aa2cde5f"},
+    {file = "pytest_asyncio-0.23.6-py3-none-any.whl", hash = "sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "pytest-cov"
@@ -979,13 +992,13 @@ testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtuale
 
 [[package]]
 name = "pytest-datadir"
-version = "1.4.1"
+version = "1.5.0"
 description = "pytest plugin for test data directories and files"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "pytest-datadir-1.4.1.tar.gz", hash = "sha256:9f7a3c4def6ac4cac3cc8181139ab53bd2667231052bd40cb07081748d4420f0"},
-    {file = "pytest_datadir-1.4.1-py3-none-any.whl", hash = "sha256:095f441782b1b907587eca7227fdbae94be43f1c96b4b2cbcc6801a4645be1af"},
+    {file = "pytest-datadir-1.5.0.tar.gz", hash = "sha256:1617ed92f9afda0c877e4eac91904b5f779d24ba8f5e438752e3ae39d8d2ee3f"},
+    {file = "pytest_datadir-1.5.0-py3-none-any.whl", hash = "sha256:34adf361bcc7b37961bbc1dfa8d25a4829e778bab461703c38a5c50ca9c36dc8"},
 ]
 
 [package.dependencies]
@@ -993,30 +1006,30 @@ pytest = ">=5.0"
 
 [[package]]
 name = "pytest-mock"
-version = "3.11.1"
+version = "3.14.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pytest-mock-3.11.1.tar.gz", hash = "sha256:7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f"},
-    {file = "pytest_mock-3.11.1-py3-none-any.whl", hash = "sha256:21c279fff83d70763b05f8874cc9cfb3fcacd6d354247a976f9529d19f9acf39"},
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
 ]
 
 [package.dependencies]
-pytest = ">=5.0"
+pytest = ">=6.2.5"
 
 [package.extras]
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "pytest-regressions"
-version = "2.4.3"
+version = "2.5.0"
 description = "Easy to use fixtures to write regression tests."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "pytest-regressions-2.4.3.tar.gz", hash = "sha256:7238036bbd17c62944bff55d73edb4993eea3f5dbb835c332ec7bc0ddeb027ed"},
-    {file = "pytest_regressions-2.4.3-py3-none-any.whl", hash = "sha256:a0fd84e45d2c3b43d2b36157045ebca8b85185d3dc7b014a62b2954a05d8e07d"},
+    {file = "pytest-regressions-2.5.0.tar.gz", hash = "sha256:818c7884c1cff3babf89eebb02cbc27b307856b1985427c24d52cb812a106fd9"},
+    {file = "pytest_regressions-2.5.0-py3-none-any.whl", hash = "sha256:8c4e5c4037325fdb0825bc1fdcb75e17e03adf3407049f0cb704bb996d496255"},
 ]
 
 [package.dependencies]
@@ -1063,27 +1076,27 @@ pytest = ">=3.6.3"
 
 [[package]]
 name = "pytest-timeout"
-version = "2.2.0"
+version = "2.3.1"
 description = "pytest plugin to abort hanging tests"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-timeout-2.2.0.tar.gz", hash = "sha256:3b0b95dabf3cb50bac9ef5ca912fa0cfc286526af17afc806824df20c2f72c90"},
-    {file = "pytest_timeout-2.2.0-py3-none-any.whl", hash = "sha256:bde531e096466f49398a59f2dde76fa78429a09a12411466f88a07213e220de2"},
+    {file = "pytest-timeout-2.3.1.tar.gz", hash = "sha256:12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9"},
+    {file = "pytest_timeout-2.3.1-py3-none-any.whl", hash = "sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e"},
 ]
 
 [package.dependencies]
-pytest = ">=5.0.0"
+pytest = ">=7.0.0"
 
 [[package]]
 name = "pytz"
-version = "2023.3.post1"
+version = "2024.1"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pytz-2023.3.post1-py2.py3-none-any.whl", hash = "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"},
-    {file = "pytz-2023.3.post1.tar.gz", hash = "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b"},
+    {file = "pytz-2024.1-py2.py3-none-any.whl", hash = "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"},
+    {file = "pytz-2024.1.tar.gz", hash = "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812"},
 ]
 
 [[package]]
@@ -1185,13 +1198,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rich"
-version = "13.7.0"
+version = "13.7.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "rich-13.7.0-py3-none-any.whl", hash = "sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235"},
-    {file = "rich-13.7.0.tar.gz", hash = "sha256:5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa"},
+    {file = "rich-13.7.1-py3-none-any.whl", hash = "sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222"},
+    {file = "rich-13.7.1.tar.gz", hash = "sha256:9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432"},
 ]
 
 [package.dependencies]
@@ -1280,13 +1293,13 @@ dev = ["bump2version", "sphinxcontrib-httpdomain", "transifex-client", "wheel"]
 
 [[package]]
 name = "sphinxcontrib-applehelp"
-version = "1.0.2"
-description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
+version = "1.0.4"
+description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.8"
 files = [
-    {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
-    {file = "sphinxcontrib_applehelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a"},
+    {file = "sphinxcontrib-applehelp-1.0.4.tar.gz", hash = "sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e"},
+    {file = "sphinxcontrib_applehelp-1.0.4-py3-none-any.whl", hash = "sha256:29d341f67fb0f6f586b23ad80e072c8e6ad0b48417db2bde114a4c9746feb228"},
 ]
 
 [package.extras]
@@ -1310,13 +1323,13 @@ test = ["pytest"]
 
 [[package]]
 name = "sphinxcontrib-htmlhelp"
-version = "2.0.0"
+version = "2.0.1"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "sphinxcontrib-htmlhelp-2.0.0.tar.gz", hash = "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"},
-    {file = "sphinxcontrib_htmlhelp-2.0.0-py2.py3-none-any.whl", hash = "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07"},
+    {file = "sphinxcontrib-htmlhelp-2.0.1.tar.gz", hash = "sha256:0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff"},
+    {file = "sphinxcontrib_htmlhelp-2.0.1-py3-none-any.whl", hash = "sha256:c38cb46dccf316c79de6e5515e1770414b797162b23cd3d06e67020e1d2a6903"},
 ]
 
 [package.extras]
@@ -1419,13 +1432,13 @@ files = [
 
 [[package]]
 name = "tqdm"
-version = "4.66.1"
+version = "4.66.2"
 description = "Fast, Extensible Progress Meter"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tqdm-4.66.1-py3-none-any.whl", hash = "sha256:d302b3c5b53d47bce91fea46679d9c3c6508cf6332229aa1e7d8653723793386"},
-    {file = "tqdm-4.66.1.tar.gz", hash = "sha256:d88e651f9db8d8551a62556d3cff9e3034274ca5d66e93197cf2490e2dcb69c7"},
+    {file = "tqdm-4.66.2-py3-none-any.whl", hash = "sha256:1ee4f8a893eb9bef51c6e35730cebf234d5d0b6bd112b0271e10ed7c24a02bd9"},
+    {file = "tqdm-4.66.2.tar.gz", hash = "sha256:6cd52cdf0fef0e0f543299cfc96fec90d7b8a7e88745f411ec33eb44d5ed3531"},
 ]
 
 [package.dependencies]
@@ -1439,41 +1452,41 @@ telegram = ["requests"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.7.1"
-description = "Backported and Experimental Type Hints for Python 3.7+"
+version = "4.11.0"
+description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
-    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
+    {file = "typing_extensions-4.11.0-py3-none-any.whl", hash = "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"},
+    {file = "typing_extensions-4.11.0.tar.gz", hash = "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"},
 ]
 
 [[package]]
 name = "urllib3"
-version = "2.0.7"
+version = "2.2.1"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
-    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
+    {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
+    {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
 ]
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
+h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "wcwidth"
-version = "0.2.12"
+version = "0.2.13"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = "*"
 files = [
-    {file = "wcwidth-0.2.12-py2.py3-none-any.whl", hash = "sha256:f26ec43d96c8cbfed76a5075dac87680124fa84e0855195a6184da9c187f133c"},
-    {file = "wcwidth-0.2.12.tar.gz", hash = "sha256:f01c104efdf57971bcb756f054dd58ddec5204dd15fa31d6503ea57947d97c02"},
+    {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
+    {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
 ]
 
 [[package]]
@@ -1557,20 +1570,20 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.15.0"
+version = "3.18.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
-    {file = "zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b"},
+    {file = "zipp-3.18.1-py3-none-any.whl", hash = "sha256:206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b"},
+    {file = "zipp-3.18.1.tar.gz", hash = "sha256:2884ed22e7d8961de1c9a05142eb69a247f120291bc0206a00a7642f09b5b715"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "ee3d9cbcbc70bc1585411a3ae62f2ec6d825a6d2493764e49ef36a710797ebbf"
+content-hash = "21d9e135940142019db0dc1f0bcabcb99a2f5109010a6e3401548e1ff00b90c6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,13 @@ pytest-timeout = "^2.2.0"
 Sphinx = "^5.0.1"
 sphinx-rtd-theme = "^1.0.0"
 toml = "^0.10.0"
+pytest-asyncio = "^0.23.6"
 
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
 markers = "--enable-internet: Allow some tests to run using real connections to the cluster."
+
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -1285,7 +1285,7 @@ def test_setup_passwordless_ssh_access_to_cluster(
     def have_passwordless_ssh_access_to(cluster: str) -> bool:
         if sys.platform == "win32":
             return check_passwordless(cluster)
-        return is_already_logged_in(cluster)
+        return is_already_logged_in(cluster, ssh_config_path=SSH_CONFIG_FILE)
 
     def _exists(file: PurePosixPath | Path):
         if cluster == "localhost":

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -1,14 +1,15 @@
 import functools
 import multiprocessing
 import random
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from prompt_toolkit.input.defaults import create_pipe_input
 
 from milatools.cli.utils import (
-    get_fully_qualified_hostname_of_compute_node,
     get_fully_qualified_name,
+    get_hostname_to_use_for_compute_node,
     make_process,
     qn,
     randname,
@@ -77,23 +78,30 @@ def test_hostname():
     #     for cnode in ["nia1234"]
     # ],
 )
-def test_get_fully_qualified_hostname_of_compute_node(
-    cluster_name: str, node: str, expected: str
+def test_get_hostname_to_use_for_compute_node(
+    cluster_name: str,
+    node: str,
+    expected: str,
+    ssh_config_file: Path,
 ):
     assert (
-        get_fully_qualified_hostname_of_compute_node(
-            node_name=node, cluster=cluster_name
+        get_hostname_to_use_for_compute_node(
+            node_name=node, cluster=cluster_name, ssh_config_path=ssh_config_file
         )
         == expected
     )
 
 
-def test_get_fully_qualified_hostname_of_compute_node_unknown_cluster():
+def test_get_fully_qualified_hostname_of_compute_node_unknown_cluster(
+    ssh_config_file: Path,
+):
     node_name = "some-node"
     with pytest.warns(UserWarning):
         assert (
-            get_fully_qualified_hostname_of_compute_node(
-                node_name=node_name, cluster="unknown-cluster"
+            get_hostname_to_use_for_compute_node(
+                node_name=node_name,
+                cluster="unknown-cluster",
+                ssh_config_path=ssh_config_file,
             )
             == node_name
         )

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -55,7 +55,7 @@ def test_hostname():
     + [
         # Host !cedar   cdr? cdr?? cdr??? cdr????
         ("cedar", cnode, cnode)
-        for n in range(5)
+        for n in range(1, 5)
         for cnode in [f"cdr{'0' * n}"]
     ]
     + [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from fabric.connection import Connection
 
 from milatools.cli import console
 from milatools.cli.init_command import setup_ssh_config
+from milatools.cli.utils import SSH_CONFIG_FILE
 from milatools.utils.compute_node import get_queued_milatools_job_ids
 from milatools.utils.remote_v1 import RemoteV1
 from milatools.utils.remote_v2 import (
@@ -134,7 +135,9 @@ def login_node(cluster: str) -> RemoteV1 | RemoteV2:
     compute nodes because a previous test kept the same connection object while doing
     salloc (just in case that were to happen).
     """
-    if cluster not in ["mila", "localhost"] and not is_already_logged_in(cluster):
+    if cluster not in ["mila", "localhost"] and not is_already_logged_in(
+        cluster, ssh_config_path=SSH_CONFIG_FILE
+    ):
         pytest.skip(
             f"Requires ssh access to the login node of the {cluster} cluster, and a "
             "prior connection to the cluster."
@@ -153,7 +156,9 @@ def login_node_v2(cluster: str) -> RemoteV2:
     """
     if sys.platform == "win32":
         pytest.skip("Test uses RemoteV2.")
-    if cluster not in ["mila", "localhost"] and not is_already_logged_in(cluster):
+    if cluster not in ["mila", "localhost"] and not is_already_logged_in(
+        cluster, ssh_config_path=SSH_CONFIG_FILE
+    ):
         pytest.skip(
             f"Requires ssh access to the login node of the {cluster} cluster, and a "
             "prior connection to the cluster."
@@ -266,7 +271,9 @@ def get_slurm_account(cluster: str) -> str:
     logger.info(
         f"Fetching the list of SLURM accounts available on the {cluster} cluster."
     )
-    assert cluster in ["mila", "localhost"] or is_already_logged_in(cluster)
+    assert cluster in ["mila", "localhost"] or is_already_logged_in(
+        cluster, ssh_config_path=SSH_CONFIG_FILE
+    )
     result = RemoteV2(cluster).run(
         "sacctmgr --noheader show associations where user=$USER format=Account%50"
     )
@@ -280,7 +287,9 @@ def get_slurm_account(cluster: str) -> str:
 
 @pytest.fixture(scope="session")
 def slurm_account_on_cluster(cluster: str) -> str:
-    if cluster not in ["mila", "localhost"] and not is_already_logged_in(cluster):
+    if cluster not in ["mila", "localhost"] and not is_already_logged_in(
+        cluster, ssh_config_path=SSH_CONFIG_FILE
+    ):
         # avoid test hanging on 2FA prompt.
         pytest.skip(reason=f"Test needs an existing connection to {cluster} to run.")
     return get_slurm_account(cluster)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,16 +221,6 @@ def cluster(request: pytest.FixtureRequest) -> str:
     if not cluster_name:
         pytest.skip("Requires ssh access to a SLURM cluster.")
 
-    clusters_in_maintenance = os.environ.get("CLUSTER_DOWN", "").split(",")
-    if cluster_name in clusters_in_maintenance:
-        pytest.skip(reason=f"Cluster {cluster_name} is down for maintenance.")
-        # TODO: Seems not possible to add this marker to all tests?.
-        # request.node.add_marker(
-        #     pytest.mark.xfail(
-        #         reason=f"Cluster {cluster_name} is down for maintenance.",
-        # raises=subprocess.CalledProcessError,
-        #     )
-        # )
     return cluster_name
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ import milatools.utils.remote_v2
 from milatools.cli import console
 from milatools.cli.init_command import setup_ssh_config
 from milatools.cli.utils import SSH_CONFIG_FILE
-from milatools.utils.compute_node_v2 import get_queued_milatools_job_ids
+from milatools.utils.compute_node import get_queued_milatools_job_ids
 from milatools.utils.remote_v1 import RemoteV1
 from milatools.utils.remote_v2 import (
     RemoteV2,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,35 +1,27 @@
 from __future__ import annotations
 
 import datetime
-import functools
 import os
 import sys
 from logging import getLogger as get_logger
 
 import pytest
 
-from milatools.utils.remote_v1 import RemoteV1
-from milatools.utils.remote_v2 import (
-    SSH_CONFIG_FILE,
-    RemoteV2,
-    is_already_logged_in,
-)
-from tests.cli.common import in_github_CI, in_self_hosted_github_CI
+from milatools.cli.utils import SSH_CONFIG_FILE
+from milatools.utils.remote_v2 import is_already_logged_in
 
 logger = get_logger(__name__)
 JOB_NAME = "milatools_test"
 WCKEY = "milatools_test"
 
-SLURM_CLUSTER = os.environ.get(
-    "SLURM_CLUSTER", "mila" if in_self_hosted_github_CI or not in_github_CI else None
-)
-"""The name of the slurm cluster to use for tests.
+SLURM_CLUSTER = os.environ.get("SLURM_CLUSTER")
+"""The name of the slurm cluster(s) to use for tests.
 
 When running the tests on a dev machine, this defaults to the Mila cluster. Set to
 `None` when running on the github CI.
 """
 
-MAX_JOB_DURATION = datetime.timedelta(seconds=10)
+MAX_JOB_DURATION = datetime.timedelta(minutes=5)
 
 hangs_in_github_CI = pytest.mark.skipif(
     SLURM_CLUSTER == "localhost",
@@ -69,73 +61,3 @@ def skip_param_if_not_already_logged_in(cluster: str):
             skip_if_not_already_logged_in(cluster),
         ],
     )
-
-
-@functools.lru_cache
-def get_slurm_account(cluster: str) -> str:
-    """Gets the SLURM account of the user using sacctmgr on the slurm cluster.
-
-    When there are multiple accounts, this selects the first account, alphabetically.
-
-    On DRAC cluster, this uses the `def` allocations instead of `rrg`, and when
-    the rest of the accounts are the same up to a '_cpu' or '_gpu' suffix, it uses
-    '_cpu'.
-
-    For example:
-
-    ```text
-    def-someprofessor_cpu  <-- this one is used.
-    def-someprofessor_gpu
-    rrg-someprofessor_cpu
-    rrg-someprofessor_gpu
-    ```
-    """
-    logger.info(
-        f"Fetching the list of SLURM accounts available on the {cluster} cluster."
-    )
-    if sys.platform == "win32":
-        result = RemoteV1(cluster).run(
-            "sacctmgr --noheader show associations where user=$USER format=Account%50"
-        )
-    else:
-        result = RemoteV2(cluster).run(
-            "sacctmgr --noheader show associations where user=$USER format=Account%50"
-        )
-    accounts = [line.strip() for line in result.stdout.splitlines()]
-    assert accounts
-    logger.info(f"Accounts on the slurm cluster {cluster}: {accounts}")
-    account = sorted(accounts)[0]
-    logger.info(f"Using account {account} to launch jobs in tests.")
-    return account
-
-
-@pytest.fixture(scope="session")
-def slurm_account(cluster: str):
-    return get_slurm_account(cluster)
-
-
-@pytest.fixture()
-def allocation_flags(
-    cluster: str, slurm_account: str, request: pytest.FixtureRequest
-) -> list[str]:
-    # note: thanks to lru_cache, this is only making one ssh connection per cluster.
-    allocation_options = {
-        "job-name": JOB_NAME,
-        "wckey": WCKEY,
-        "account": slurm_account,
-        "nodes": 1,
-        "ntasks": 1,
-        "cpus-per-task": 1,
-        "mem": "1G",
-        "time": MAX_JOB_DURATION,
-        "oversubscribe": None,  # allow multiple such jobs to share resources.
-    }
-    overrides = getattr(request, "param", {})
-    assert isinstance(overrides, dict)
-    if overrides:
-        print(f"Overriding allocation options with {overrides}")
-        allocation_options.update(overrides)
-    return [
-        f"--{key}={value}" if value is not None else f"--{key}"
-        for key, value in allocation_options.items()
-    ]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,7 +41,7 @@ def skip_if_not_already_logged_in(cluster: str) -> pytest.MarkDecorator:
     return pytest.mark.skipif(
         sys.platform == "win32"
         or not SSH_CONFIG_FILE.exists()
-        or not is_already_logged_in(cluster),
+        or not is_already_logged_in(cluster, ssh_config_path=SSH_CONFIG_FILE),
         reason=(
             f"Logging into {cluster} might go through 2FA. It should be done "
             "in advance."

--- a/tests/integration/test_code_command.py
+++ b/tests/integration/test_code_command.py
@@ -14,7 +14,7 @@ from milatools.cli.utils import get_hostname_to_use_for_compute_node
 from milatools.utils.remote_v1 import RemoteV1
 from milatools.utils.remote_v2 import RemoteV2
 
-from ..cli.common import in_github_CI, skip_param_if_on_github_ci
+from ..cli.common import in_github_CI, skip_param_if_on_github_cloud_ci
 from .conftest import (
     SLURM_CLUSTER,
     hangs_in_github_CI,
@@ -29,7 +29,7 @@ logger = get_logger(__name__)
 @pytest.mark.parametrize(
     "cluster",
     [
-        skip_param_if_on_github_ci("mila"),
+        skip_param_if_on_github_cloud_ci("mila"),
         skip_param_if_not_already_logged_in("narval"),
         skip_param_if_not_already_logged_in("beluga"),
         skip_param_if_not_already_logged_in("cedar"),
@@ -78,7 +78,7 @@ def test_check_disk_quota(
                 hangs_in_github_CI,
             ],
         ),
-        skip_param_if_on_github_ci("mila"),
+        skip_param_if_on_github_cloud_ci("mila"),
         # TODO: Re-enable these tests once we make `code` work with RemoteV2
         pytest.param("narval", marks=pytest.mark.skip(reason="Goes through 2FA!")),
         pytest.param("beluga", marks=pytest.mark.skip(reason="Goes through 2FA!")),

--- a/tests/integration/test_code_command.py
+++ b/tests/integration/test_code_command.py
@@ -10,7 +10,7 @@ from logging import getLogger as get_logger
 import pytest
 
 from milatools.cli.commands import check_disk_quota, code
-from milatools.cli.utils import get_fully_qualified_hostname_of_compute_node
+from milatools.cli.utils import get_hostname_to_use_for_compute_node
 from milatools.utils.remote_v1 import RemoteV1
 from milatools.utils.remote_v2 import RemoteV2
 
@@ -135,7 +135,7 @@ def test_code(
     job_info = job_id_to_job_info[job_id]
 
     node = job_info["Node"]
-    node_hostname = get_fully_qualified_hostname_of_compute_node(
+    node_hostname = get_hostname_to_use_for_compute_node(
         node, cluster=login_node.hostname
     )
     expected_line = f"(local) $ /usr/bin/echo -nw --remote ssh-remote+{node_hostname} {home}/{relative_path}"

--- a/tests/integration/test_code_command.py
+++ b/tests/integration/test_code_command.py
@@ -106,15 +106,17 @@ def test_code(
     # before submitting the job)
     workdir = job_info["WorkDir"]
     assert workdir == scratch
-
-    if persist:
-        # Job should still be running since we're using `persist` (that's the whole
-        # point.)
-        assert job_info["State"] == "RUNNING"
-    else:
-        # Job should have been cancelled by us after the `echo` process finished.
-        # NOTE: This check is a bit flaky, perhaps our `scancel` command hasn't
-        # completed yet, or sacct doesn't show the change in status quick enough.
-        # Relaxing it a bit for now.
-        # assert "CANCELLED" in job_info["State"]
-        assert "CANCELLED" in job_info["State"] or job_info["State"] == "RUNNING"
+    try:
+        if persist:
+            # Job should still be running since we're using `persist` (that's the whole
+            # point.)
+            assert job_info["State"] == "RUNNING"
+        else:
+            # Job should have been cancelled by us after the `echo` process finished.
+            # NOTE: This check is a bit flaky, perhaps our `scancel` command hasn't
+            # completed yet, or sacct doesn't show the change in status quick enough.
+            # Relaxing it a bit for now.
+            # assert "CANCELLED" in job_info["State"]
+            assert "CANCELLED" in job_info["State"] or job_info["State"] == "RUNNING"
+    finally:
+        login_node.run(f"scancel {job_id}", display=True)

--- a/tests/integration/test_slurm_remote.py
+++ b/tests/integration/test_slurm_remote.py
@@ -69,13 +69,14 @@ def get_recent_jobs_info(
     # otherwise this would launch a job!
     assert not isinstance(login_node, SlurmRemote)
     lines = login_node.run(
-        f"sacct --noheader --allocations "
+        f"sacct --noheader --allocations --user=$USER "
         f"--starttime=now-{int(since.total_seconds())}seconds "
-        "--format=" + ",".join(f"{field}%40" for field in fields),
-        display=True,
+        "--format=" + ",".join(f"{field}%100" for field in fields),
+        display=False,
+        hide=True,
     ).stdout.splitlines()
     # note: using maxsplit because the State field can contain spaces: "canceled by ..."
-    return [tuple(line.strip().split(maxsplit=len(fields))) for line in lines]
+    return [tuple(line.strip().split(maxsplit=len(fields) - 1)) for line in lines]
 
 
 def sleep_so_sacct_can_update():

--- a/tests/integration/test_sync_command.py
+++ b/tests/integration/test_sync_command.py
@@ -16,7 +16,6 @@ from milatools.utils.vscode_utils import (
     install_vscode_extensions_task_function,
     sync_vscode_extensions,
 )
-from tests.integration.conftest import skip_param_if_not_already_logged_in
 
 from ..cli.common import (
     requires_ssh_to_localhost,
@@ -30,31 +29,27 @@ logger = get_logger(__name__)
     "source",
     [
         pytest.param("localhost", marks=requires_ssh_to_localhost),
-        skip_param_if_not_already_logged_in("mila"),
-        skip_param_if_not_already_logged_in("narval"),
-        skip_param_if_not_already_logged_in("beluga"),
-        skip_param_if_not_already_logged_in("cedar"),
-        skip_param_if_not_already_logged_in("graham"),
-        skip_param_if_not_already_logged_in("niagara"),
+        "cluster",
     ],
 )
 @pytest.mark.parametrize(
     "dest",
     [
         pytest.param("localhost", marks=requires_ssh_to_localhost),
-        skip_param_if_not_already_logged_in("mila"),
-        skip_param_if_not_already_logged_in("narval"),
-        skip_param_if_not_already_logged_in("beluga"),
-        skip_param_if_not_already_logged_in("cedar"),
-        skip_param_if_not_already_logged_in("graham"),
-        skip_param_if_not_already_logged_in("niagara"),
+        "cluster",
     ],
 )
 def test_sync_vscode_extensions(
     source: str,
     dest: str,
+    cluster: str,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    if source == "cluster":
+        source = cluster
+    if dest == "cluster":
+        dest = cluster
+
     if source == dest:
         pytest.skip("Source and destination are the same.")
 
@@ -83,7 +78,6 @@ def test_sync_vscode_extensions(
         source=LocalV1() if source == "localhost" else RemoteV2(source),
         dest_clusters=[dest],
     )
-
     mock_task_function.assert_called_once()
     mock_extensions_to_install.assert_called_once()
     if source == "localhost":

--- a/tests/utils/runner_tests.py
+++ b/tests/utils/runner_tests.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import abc
+import asyncio
+import logging
+import re
+import subprocess
+import time
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from milatools.utils.remote_v1 import Hide
+from milatools.utils.remote_v2 import RemoteV2
+from milatools.utils.runner import Runner
+
+
+class RunnerTests(abc.ABC):
+    """Tests for a `Runner` implementation.
+
+    Subclasses have to implement these methods:
+    - the `runner` fixture which should ideally be class or session-scoped;
+    - the `command_with_result` fixture should return a tuple containing 3 items:
+        - The command to run successfully
+        - the expected stdout or a `re.Pattern` to match against the stdout
+        - the expected stderr or a `re.Pattern` to match against the stderr
+    - the `command_with_exception_and_stderr` fixture should return a tuple containing 3 items:
+        (The command to run uncessfully, the expected exception, the expected stderr).
+    """
+
+    @abc.abstractmethod
+    @pytest.fixture(scope="class")
+    def runner(self) -> Runner:
+        raise NotImplementedError()
+
+    @pytest.fixture(
+        scope="class",
+        params=[
+            ("echo OK", "OK", ""),
+        ],
+    )
+    def command_with_result(self, request: pytest.FixtureRequest):
+        """Parametrized fixture for commands that are expected to raise an exception.
+
+        These should be a tuple of:
+        - the command to run
+        - the expected stdout or a regular expression that matches stdout;
+        - the expected stderr or a regular expression that matches stderr
+
+        Subclasses should override this fixture to provide more commands to run.
+        """
+        return request.param
+
+    # @abc.abstractmethod
+    @pytest.fixture(
+        scope="class",
+        params=[
+            (
+                "cat /does/not/exist",
+                subprocess.CalledProcessError,
+                re.compile(r"cat: /does/not/exist: No such file or directory"),
+            ),
+        ],
+    )
+    def command_with_exception_and_stderr(self, request: pytest.FixtureRequest):
+        """Parametrized fixture for commands that are expected to raise an exception.
+
+        These should be a tuple of:
+        - the command to run
+        - The type of exception that is expected to be raised
+        - a string or regular expression that matches stderr.
+
+        Subclasses should override this fixture to provide more commands to run.
+        """
+        return request.param
+
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    @pytest.mark.parametrize("display", [True, False])
+    @pytest.mark.parametrize("hide", [True, False, "out", "err", "stdout", "stderr"])
+    @pytest.mark.asyncio
+    async def test_run(
+        self,
+        runner: Runner,
+        command_with_result: tuple[str, str | re.Pattern, str | re.Pattern],
+        hide: Hide,
+        display: bool,
+        capsys: pytest.CaptureFixture,
+        caplog: pytest.LogCaptureFixture,
+        use_async: bool,
+    ):
+        command, expected_output, expected_err = command_with_result
+
+        if use_async:
+            result = await runner.run_async(command, display=display, hide=hide)
+        else:
+            result = runner.run(command, display=display, hide=hide)
+
+        self._shared_run_checks(
+            runner=runner,
+            hide=hide,
+            display=display,
+            capsys=capsys,
+            caplog=caplog,
+            command=command,
+            expected_output=expected_output,
+            expected_err=expected_err,
+            result=result,
+            warn=False,
+        )
+
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    @pytest.mark.parametrize("display", [True, False])
+    @pytest.mark.parametrize("hide", [True, False, "out", "err", "stdout", "stderr"])
+    @pytest.mark.asyncio
+    async def test_run_with_error(
+        self,
+        runner: Runner,
+        command_with_exception_and_stderr: tuple[
+            str, type[Exception], str | re.Pattern
+        ],
+        hide: Hide,
+        display: bool,
+        use_async: bool,
+    ):
+        command, expected_exception, expected_err = command_with_exception_and_stderr
+
+        assert isinstance(expected_exception, type) and issubclass(
+            expected_exception, Exception
+        )
+        # Should raise an exception of this type.
+        with pytest.raises(expected_exception=expected_exception):
+            if use_async:
+                _ = await runner.run_async(command, display=display, hide=hide)
+            else:
+                _ = runner.run(command, display=display, hide=hide)
+
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    @pytest.mark.parametrize("display", [True, False])
+    @pytest.mark.parametrize("hide", [True, False, "out", "err", "stdout", "stderr"])
+    @pytest.mark.asyncio
+    async def test_run_with_error_warn(
+        self,
+        runner: Runner,
+        command_with_exception_and_stderr: tuple[
+            str, type[Exception], str | re.Pattern
+        ],
+        hide: Hide,
+        display: bool,
+        capsys: pytest.CaptureFixture,
+        caplog: pytest.LogCaptureFixture,
+        use_async: bool,
+    ):
+        command, expected_exception, expected_err = command_with_exception_and_stderr
+
+        assert isinstance(expected_exception, type) and issubclass(
+            expected_exception, Exception
+        )
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="milatools"):
+            if use_async:
+                result = await runner.run_async(
+                    command, display=display, hide=hide, warn=True
+                )
+            else:
+                result = runner.run(command, display=display, hide=hide, warn=True)
+
+        assert result.stdout == ""
+        self._shared_run_checks(
+            runner=runner,
+            hide=hide,
+            display=display,
+            capsys=capsys,
+            caplog=caplog,
+            command=command,
+            expected_output="",
+            expected_err=expected_err,
+            result=result,
+            warn=True,
+        )
+
+    def _shared_run_checks(
+        self,
+        runner: Runner,
+        hide: Hide,
+        display: bool,
+        capsys: pytest.CaptureFixture,
+        caplog: pytest.LogCaptureFixture,
+        command: str,
+        expected_output: str | re.Pattern,
+        expected_err: str | re.Pattern,
+        result: subprocess.CompletedProcess,
+        warn: bool,
+    ):
+        self._check_result(expected_output, expected_err, result)
+        self._check_printed_stdout_stderr(
+            runner=runner,
+            command=command,
+            display=display,
+            hide=hide,
+            result=result,
+            capsys=capsys,
+        )
+        self._check_warning_logs(
+            hide=hide,
+            caplog=caplog,
+            command=command,
+            expected_err=expected_err,
+            warn=warn,
+        )
+
+    def _check_printed_stdout_stderr(
+        self,
+        runner: Runner,
+        command: str,
+        display: bool,
+        hide: Hide,
+        result: subprocess.CompletedProcess,
+        capsys: pytest.CaptureFixture,
+    ):
+        printed_output, printed_err = capsys.readouterr()
+        assert isinstance(printed_output, str)
+        assert isinstance(printed_err, str)
+
+        assert (f"({runner.hostname}) $ {command}" in printed_output) == display
+
+        if result.stdout:
+            stdout_should_be_printed = hide not in [
+                True,
+                "out",
+                "stdout",
+            ]
+            stdout_was_printed = result.stdout in printed_output
+            assert stdout_was_printed == stdout_should_be_printed
+
+        if result.stderr:
+            error_should_be_printed = hide not in [
+                True,
+                "err",
+                "stderr",
+            ]
+            error_was_printed = result.stderr in printed_err
+            assert error_was_printed == error_should_be_printed, (
+                result.stderr,
+                printed_err,
+            )
+
+    def _check_result(
+        self,
+        expected_output: str | re.Pattern,
+        expected_err: str | re.Pattern,
+        result: subprocess.CompletedProcess,
+    ):
+        if isinstance(expected_output, re.Pattern):
+            assert expected_output.search(result.stdout)
+        else:
+            assert result.stdout.strip() == expected_output
+
+        if isinstance(expected_err, re.Pattern):
+            assert expected_err.search(result.stderr)
+        else:
+            assert result.stderr.strip() == expected_err
+
+    def _check_warning_logs(
+        self,
+        command: str,
+        warn: bool,
+        hide: Hide,
+        expected_err: str | re.Pattern,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        if not warn:
+            # No warnings should have been logged.
+            assert not any(
+                record.levelname in ("WARNING", "ERROR", "CRITICAL")
+                for record in caplog.records
+            )
+            return
+
+        if hide is True:
+            # Warnings not logged at all (because `warn=True` and `hide=True`).
+            assert caplog.records == []
+        elif isinstance(expected_err, str):
+            assert len(caplog.records) == 1
+            assert (
+                caplog.records[0].message.strip()
+                == f"Command {command!r} returned non-zero exit code 1: {expected_err}"
+            )
+        elif isinstance(expected_err, re.Pattern):
+            assert len(caplog.records) == 1
+            message = caplog.records[0].message.strip()
+            assert expected_err.search(message)
+
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    @pytest.mark.asyncio
+    async def test_get_output_calls_run(
+        self,
+        runner: Runner,
+        use_async: bool,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        mock = Mock(spec=subprocess.CompletedProcess, stdout=Mock())
+        command = "echo OK"
+        if use_async:
+            if (
+                runner.run_async is type(runner).run_async
+                and runner.get_output_async is type(runner).get_output_async
+            ):
+                # It's a static method! Path the class instead of the "instance".
+                monkeypatch.setattr(
+                    type(runner),
+                    type(runner).run_async.__name__,
+                    AsyncMock(spec=runner.run_async, spec_set=True, return_value=mock),
+                )
+            else:
+                monkeypatch.setattr(
+                    runner,
+                    runner.run_async.__name__,
+                    AsyncMock(spec=runner.run_async, spec_set=True, return_value=mock),
+                )
+            output = await runner.get_output_async(command)
+        else:
+            if (
+                runner.run is type(runner).run
+                and runner.get_output is type(runner).get_output
+            ):
+                # It's a static method! Path the class instead.
+                monkeypatch.setattr(
+                    type(runner),
+                    type(runner).run.__name__,
+                    Mock(spec=runner.run, spec_set=True, return_value=mock),
+                )
+            else:
+                # It's a regular method:
+                monkeypatch.setattr(
+                    runner,
+                    runner.run.__name__,
+                    Mock(spec=runner.run, spec_set=True, return_value=mock),
+                )
+            output = runner.get_output(command)
+        assert isinstance(output, Mock)
+        assert output is mock.stdout.strip()
+
+    @pytest.mark.asyncio
+    async def test_run_async_runs_in_parallel(self, runner: RemoteV2):
+        commands = [f"sleep {i}" for i in range(1, 3)]
+        start_time = time.time()
+        # Sequential time:
+        sequential_results = [runner.get_output(command) for command in commands]
+        sequential_time = time.time() - start_time
+
+        start_time = time.time()
+        parallel_results = await asyncio.gather(
+            *(runner.get_output_async(command) for command in commands),
+            return_exceptions=False,
+        )
+        parallel_time = time.time() - start_time
+
+        assert sequential_results == parallel_results
+        assert parallel_time < sequential_time

--- a/tests/utils/runner_tests.py
+++ b/tests/utils/runner_tests.py
@@ -305,7 +305,7 @@ class RunnerTests(abc.ABC):
                 runner.run_async is type(runner).run_async
                 and runner.get_output_async is type(runner).get_output_async
             ):
-                # It's a static method! Path the class instead of the "instance".
+                # It's a static method! Patch the class instead of the "instance".
                 monkeypatch.setattr(
                     type(runner),
                     type(runner).run_async.__name__,

--- a/tests/utils/test_compute_node.py
+++ b/tests/utils/test_compute_node.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+import subprocess
+from logging import getLogger as get_logger
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+import pytest_asyncio
+
+from milatools.cli.utils import removesuffix
+from milatools.utils.compute_node import (
+    ComputeNode,
+    JobNotRunningError,
+    get_queued_milatools_job_ids,
+    salloc,
+    sbatch,
+)
+from milatools.utils.remote_v2 import RemoteV2
+
+from ..conftest import launches_jobs
+from .runner_tests import RunnerTests
+from .test_remote_v2 import uses_remote_v2
+
+logger = get_logger(__name__)
+pytestmark = [uses_remote_v2]
+
+
+@launches_jobs
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_salloc(
+    login_node_v2: RemoteV2,
+    allocation_flags: list[str],
+    job_name: str,
+):
+    if login_node_v2.hostname == "localhost":
+        # todo: Check why this (and other tests in this file) don't work on the mock
+        # slurm cluster during the CI.
+        # - perhaps there is only one 'node' and so only one 'job' can run, and tests
+        #   are actually running more than one job, so blocking each other?
+        pytest.skip(reason="Test doesn't currently work on the mock slurm cluster.")
+
+    compute_node = await salloc(login_node_v2, allocation_flags, job_name=job_name)
+
+    assert isinstance(compute_node, ComputeNode)
+    assert compute_node.hostname != login_node_v2.hostname
+
+    # note: needs to be properly quoted so as not to evaluate the variable here!
+    job_id = compute_node.get_output("echo $SLURM_JOB_ID")
+    assert job_id.isdigit()
+    assert compute_node.job_id == int(job_id)
+
+    all_slurm_env_vars = {
+        (split := line.split("="))[0]: split[1]
+        for line in compute_node.get_output("env | grep SLURM").splitlines()
+    }
+    # NOTE: We actually do have all the other SLURM env variables here because we're
+    # using `srun` with the job id on the login node to run our jobs.
+    assert all_slurm_env_vars["SLURM_JOB_ID"] == str(compute_node.job_id)
+    assert len(all_slurm_env_vars) > 1
+    await compute_node.close_async()
+
+
+@launches_jobs
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_sbatch(
+    login_node_v2: RemoteV2,
+    allocation_flags: list[str],
+    job_name: str,
+):
+    if login_node_v2.hostname == "localhost":
+        pytest.skip(reason="Test doesn't currently work on the mock slurm cluster.")
+
+    compute_node = await sbatch(login_node_v2, allocation_flags, job_name=job_name)
+    assert isinstance(compute_node, ComputeNode)
+
+    assert compute_node.hostname != login_node_v2.hostname
+    job_id = compute_node.get_output("echo $SLURM_JOB_ID")
+    assert job_id.isdigit()
+    assert compute_node.job_id == int(job_id)
+    all_slurm_env_vars = {
+        (split := line.split("="))[0]: split[1]
+        for line in compute_node.get_output("env | grep SLURM").splitlines()
+    }
+    assert all_slurm_env_vars["SLURM_JOB_ID"] == str(compute_node.job_id)
+    assert len(all_slurm_env_vars) > 1
+    await compute_node.close_async()
+
+
+@pytest.fixture(scope="session", params=[True, False], ids=["sbatch", "salloc"])
+def persist(request: pytest.FixtureRequest):
+    return request.param
+
+
+@launches_jobs
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_interrupt_allocation(
+    login_node_v2: RemoteV2,
+    allocation_flags: list[str],
+    job_name: str,
+    persist: bool,
+):
+    """Test that checks that interrupting `salloc` or `sbatch` cancels the job
+    allocation.
+
+    TODO: Try to get better control over when the interrupt happens, for example:
+    - while connecting via ssh;
+    - while waiting for the job to show up in `sacct`;
+    - while waiting for the job to start running.
+    """
+    if login_node_v2.hostname == "localhost":
+        pytest.skip(reason="Test doesn't currently work on the mock slurm cluster.")
+
+    async def get_jobs_in_squeue() -> set[int]:
+        return await get_queued_milatools_job_ids(login_node_v2, job_name=job_name)
+
+    _jobs_before = await get_jobs_in_squeue()
+
+    async def get_new_job_ids() -> set[int]:
+        """Retrieves the ID of the new jobs since we called `salloc` or `sbatch`."""
+        new_job_ids: set[int] = set()
+        queued_jobs = await get_jobs_in_squeue()
+        new_job_ids = queued_jobs - _jobs_before
+
+        while not new_job_ids:
+            queued_jobs = await get_jobs_in_squeue()
+            logger.info(f"{_jobs_before=}, {queued_jobs=}")
+            new_job_ids = queued_jobs - _jobs_before
+            if new_job_ids:
+                break
+            logger.info("Waiting for the job to show up in the output of `squeue`.")
+            await asyncio.sleep(0.1)
+        return new_job_ids
+
+    # Check that a job allocation was indeed created.
+    # NOTE: Assuming that it takes more time for the job to be allocated than it takes for
+    # the job to show up in `squeue`.
+    salloc_task = asyncio.create_task(
+        sbatch(login_node_v2, sbatch_flags=allocation_flags, job_name=job_name)
+        if persist
+        else salloc(login_node_v2, salloc_flags=allocation_flags, job_name=job_name),
+        name="sbatch" if persist else "salloc",
+    )
+    get_new_job_ids_task = asyncio.create_task(
+        get_new_job_ids(), name="get_new_job_ids"
+    )
+
+    new_job_ids = await asyncio.wait_for(get_new_job_ids_task, timeout=None)
+    assert not salloc_task.done()  # hopefully we get the job ID from SQUEUE before the
+    # job is actually running...
+    salloc_task.cancel(
+        msg="Interrupting the job allocation as soon as the job ID shows up in squeue."
+    )
+    assert new_job_ids and len(new_job_ids) == 1
+    new_job_id = new_job_ids.pop()
+    # wait long enough for `squeue` to update and not show the job anymore.
+    await asyncio.sleep(10)
+    jobs_after = await get_jobs_in_squeue()
+    assert new_job_id not in jobs_after
+    assert jobs_after <= _jobs_before
+
+
+@launches_jobs
+@pytest.mark.slow
+class TestComputeNode(RunnerTests):
+    @pytest_asyncio.fixture(scope="class")
+    async def runner(
+        self, login_node_v2: RemoteV2, persist: bool, allocation_flags: list[str]
+    ):
+        if login_node_v2.hostname == "localhost":
+            pytest.skip(reason="Test doesn't currently work on the mock slurm cluster.")
+
+        if persist:
+            runner = await sbatch(
+                login_node_v2, sbatch_flags=allocation_flags, job_name="mila-code"
+            )
+        else:
+            runner = await salloc(
+                login_node_v2, salloc_flags=allocation_flags, job_name="mila-code"
+            )
+        yield runner
+        await runner.close_async()
+
+    @pytest.fixture(
+        scope="class",
+        params=[
+            ("echo OK", "OK", ""),
+            ("echo $SLURM_JOB_ID", re.compile(r"^[0-9]+"), ""),
+            ("echo $SLURM_PROCID", "0", ""),
+        ],
+    )
+    def command_and_expected_result(self, request: pytest.FixtureRequest):
+        return request.param
+
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    @pytest.mark.asyncio
+    async def test_run_gets_executed_in_job_step(
+        self, runner: ComputeNode, use_async: bool
+    ):
+        command = "echo $SLURM_STEP_ID"
+        output_a = (
+            await runner.get_output_async(command)
+            if use_async
+            else runner.get_output(command)
+        )
+        output_b = (
+            await runner.get_output_async(command)
+            if use_async
+            else runner.get_output(command)
+        )
+        job_step_a = int(output_a)
+        job_step_b = int(output_b)
+        assert job_step_a >= 0
+        assert job_step_b == job_step_a + 1
+
+    @pytest.mark.asyncio
+    async def test_connect(self, runner: ComputeNode):
+        login_node = runner.login_node
+        job_id = runner.job_id
+        node_hostname = runner.hostname
+        compute_node_with_jobid = await ComputeNode.connect(
+            login_node, job_id_or_node_name=job_id
+        )
+        assert compute_node_with_jobid.salloc_subprocess is None
+        assert compute_node_with_jobid == runner
+
+        # Need to connect with the node name, not the full node hostname.
+        # For the `mila` cluster, we don't currently have a `cn-?????` entry in the ssh
+        # config (although we could!)
+        # Therefore, we need to connect to the node with the full hostname. However
+        # squeue expects the node name, so we have to truncate it manually for now.
+        if node_hostname.endswith(".server.mila.quebec"):
+            node_name = removesuffix(node_hostname, ".server.mila.quebec")
+        else:
+            node_name = node_hostname
+
+        compute_node_with_node_name = await ComputeNode.connect(
+            login_node, job_id_or_node_name=node_name
+        )
+        assert compute_node_with_jobid.salloc_subprocess is None
+        assert compute_node_with_node_name == runner
+
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    @pytest.mark.asyncio
+    async def test_close(
+        self,
+        login_node_v2: RemoteV2,
+        persist: bool,
+        allocation_flags: list[str],
+        job_name: str,
+        use_async: bool,
+    ):
+        if login_node_v2.hostname == "localhost":
+            pytest.skip(reason="Test doesn't currently work on the mock slurm cluster.")
+        # Here we create a new job allocation just to cancel it. We could reuse the
+        # `runner` fixture, but that would require us to run this test as the very last one.
+        if persist:
+            compute_node = await sbatch(
+                login_node_v2, sbatch_flags=allocation_flags, job_name=job_name
+            )
+        else:
+            compute_node = await salloc(
+                login_node_v2, salloc_flags=allocation_flags, job_name=job_name
+            )
+
+        if use_async:
+            await compute_node.close_async()
+        else:
+            compute_node.close()
+
+        job_state = await login_node_v2.get_output_async(
+            f"sacct --noheader --allocations --jobs {compute_node.job_id} --format=State%100",
+            display=True,
+            hide=False,
+        )
+        if persist:
+            # batch jobs are scancelled.
+            assert job_state.startswith("CANCELLED")
+        else:
+            # interactive jobs are exited cleanly.
+            assert job_state == "COMPLETED"
+
+
+@launches_jobs
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_del_computenode(
+    login_node_v2: RemoteV2, persist: bool, allocation_flags: list[str], job_name: str
+):
+    """Test what happens when we delete a ComputeNode instance (persistent vs non-
+    persistent).
+
+    TODO: Perhaps we could use mocks here instead of allocating a job just to end it after.
+    """
+    if persist:
+        compute_node = await sbatch(
+            login_node_v2, sbatch_flags=allocation_flags, job_name=job_name
+        )
+    else:
+        compute_node = await salloc(
+            login_node_v2, salloc_flags=allocation_flags, job_name=job_name
+        )
+
+    job_id = compute_node.job_id
+    del compute_node
+    # if deleting does anything, wait for its effect to propagate to sacct
+    await asyncio.sleep(5)
+    state_after = await login_node_v2.get_output_async(
+        f"sacct --jobs {job_id} --allocations --noheader --format=State",
+    )
+    try:
+        if persist:
+            assert state_after == "RUNNING"
+        else:
+            assert state_after == "COMPLETED"
+    finally:
+        await login_node_v2.run_async(f"scancel {job_id}")
+
+
+@pytest_asyncio.fixture(params=[False, True], ids=["sync", "async"])
+async def mock_closed_compute_node(
+    request: pytest.FixtureRequest,
+    ssh_config_file: Path,
+):
+    """Cheaply constructs a *closed* ComputeNode, without launching any jobs."""
+    close_async: bool = request.param
+
+    fake_job_id = 1234
+
+    def _mock_run(command: str, *args, input: str | None = None, **kwargs):
+        if input == "echo $SLURMD_NODENAME\n":
+            return subprocess.CompletedProcess(command, 0, "cn-a001", "")
+        if command == f"scancel {fake_job_id}":
+            return subprocess.CompletedProcess(command, 0, "", "")
+        # Unexpected command.
+        assert False, (command, input)
+
+    async def _mock_run_async(command: str, *args, input: str | None = None, **kwargs):
+        if command == f"scancel {fake_job_id}":
+            return subprocess.CompletedProcess(command, 0, "", "")
+        # Unexpected command.
+        assert False, (command, input)
+
+    mock_run = Mock(spec=RemoteV2.run, side_effect=_mock_run)
+    mock_run_async = AsyncMock(spec=RemoteV2.run_async, side_effect=_mock_run_async)
+    mock_login_node = Mock(
+        spec=RemoteV2,
+        hostname="mila",
+        ssh_config_path=ssh_config_file,
+    )
+    mock_login_node.configure_mock(
+        run=mock_run,
+        run_async=mock_run_async,
+    )
+    compute_node = ComputeNode(mock_login_node, job_id=1234)
+    mock_run.assert_called()
+    mock_run_async.assert_not_called()
+    mock_run.reset_mock()
+
+    if close_async:
+        await compute_node.close_async()
+        mock_run_async.assert_called_once()
+        assert mock_run_async.mock_calls[0].args[0] == f"scancel {fake_job_id}"
+    else:
+        compute_node.close()
+        # bug? this doesn't work but the output is identical?
+        # mock_run.assert_called_once_with(f"scancel {fake_job_id}")
+        mock_run.assert_called_once()
+        assert mock_run.mock_calls[0].args[0] == f"scancel {fake_job_id}"
+    mock_run.reset_mock()
+    mock_run_async.reset_mock()
+    return compute_node
+
+
+@pytest.mark.asyncio
+async def test_using_closed_compute_node_raises_error(
+    mock_closed_compute_node: ComputeNode,
+):
+    compute_node = mock_closed_compute_node
+    assert isinstance(compute_node.login_node, Mock)
+    mock_run: Mock = mock_closed_compute_node.login_node.run  # type: ignore
+    mock_run_async: Mock = compute_node.login_node.run_async  # type: ignore
+    for method in ["run", "run_async", "get_output", "get_output_async"]:
+        with pytest.raises(JobNotRunningError):
+            output_or_coroutine = getattr(compute_node, method)("echo OK")
+            # if we get here it means it's a coroutine, since we'd otherwise have raised
+            # the error.
+            assert inspect.iscoroutine(output_or_coroutine)
+            await output_or_coroutine
+
+        mock_run.assert_not_called()
+        mock_run_async.assert_not_called()

--- a/tests/utils/test_compute_node.py
+++ b/tests/utils/test_compute_node.py
@@ -81,7 +81,6 @@ async def test_sbatch(
 
     assert compute_node.hostname != login_node_v2.hostname
     job_id = compute_node.get_output("echo $SLURM_JOB_ID")
-    assert job_id.isdigit()
     assert compute_node.job_id == int(job_id)
     all_slurm_env_vars = {
         (split := line.split("="))[0]: split[1]

--- a/tests/utils/test_local_v1.py
+++ b/tests/utils/test_local_v1.py
@@ -15,7 +15,7 @@ from ..cli.common import (
     output_tester,
     passwordless_ssh_connection_to_localhost_is_setup,
     requires_no_s_flag,
-    skip_if_on_github_CI,
+    skip_if_on_github_cloud_CI,
     xfails_on_windows,
 )
 
@@ -152,7 +152,7 @@ paramiko_openssh_key_parsing_issue = pytest.mark.xfail(
             False,
             marks=[
                 paramiko_openssh_key_parsing_issue,
-                skip_if_on_github_CI,
+                skip_if_on_github_cloud_CI,
             ],
         ),
         # For the clusters with 2FA, we expect `check_passwordless` to return True if
@@ -161,7 +161,7 @@ paramiko_openssh_key_parsing_issue = pytest.mark.xfail(
             "blablabob@narval",
             False,
             marks=[
-                skip_if_on_github_CI,
+                skip_if_on_github_cloud_CI,
                 paramiko_openssh_key_parsing_issue,
             ],
         ),
@@ -182,7 +182,7 @@ paramiko_openssh_key_parsing_issue = pytest.mark.xfail(
             "niagara",
             False,
             marks=[
-                skip_if_on_github_CI,
+                skip_if_on_github_cloud_CI,
                 paramiko_openssh_key_parsing_issue,
             ],
         ),  # SSH access to niagara isn't enabled by default.

--- a/tests/utils/test_local_v1.py
+++ b/tests/utils/test_local_v1.py
@@ -6,6 +6,7 @@ from subprocess import PIPE
 import pytest
 from pytest_regressions.file_regression import FileRegressionFixture
 
+from milatools.cli.utils import SSH_CONFIG_FILE
 from milatools.utils.local_v1 import CommandNotFoundError, LocalV1, check_passwordless
 from milatools.utils.remote_v2 import is_already_logged_in
 
@@ -172,7 +173,10 @@ paramiko_openssh_key_parsing_issue = pytest.mark.xfail(
                 drac_cluster,
                 True,
                 marks=pytest.mark.skipif(
-                    sys.platform == "win32" or not is_already_logged_in(drac_cluster),
+                    sys.platform == "win32"
+                    or not is_already_logged_in(
+                        drac_cluster, ssh_config_path=SSH_CONFIG_FILE
+                    ),
                     reason="Should give True when we're already logged in.",
                 ),
             )

--- a/tests/utils/test_local_v2.py
+++ b/tests/utils/test_local_v2.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import pytest
+
+from milatools.utils.local_v2 import LocalV2
+from milatools.utils.runner import Runner
+
+from .runner_tests import RunnerTests
+
+
+class TestLocalV2(RunnerTests):
+    @pytest.fixture(scope="class")
+    def runner(self) -> Runner:
+        return LocalV2()

--- a/tests/utils/test_remote_v2.py
+++ b/tests/utils/test_remote_v2.py
@@ -1,87 +1,193 @@
+from __future__ import annotations
+
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+import pytest_asyncio
 
 import milatools.utils.remote_v2
+from milatools.utils.local_v2 import LocalV2
 from milatools.utils.remote_v2 import (
     RemoteV2,
     UnsupportedPlatformError,
     control_socket_is_running,
+    control_socket_is_running_async,
     get_controlpath_for,
     is_already_logged_in,
 )
-from tests.integration.conftest import skip_param_if_not_already_logged_in
 
-from ..cli.common import requires_ssh_to_localhost, xfails_on_windows
+from ..cli.common import (
+    requires_ssh_to_localhost,
+    xfails_on_windows,
+)
+from .runner_tests import RunnerTests
 
-pytestmark = [xfails_on_windows(raises=UnsupportedPlatformError, strict=True)]
+uses_remote_v2 = xfails_on_windows(
+    raises=UnsupportedPlatformError, reason="Uses RemoteV2", strict=False
+)
+
+pytestmark = [uses_remote_v2]
 
 
-@requires_ssh_to_localhost
-def test_init_with_controlpath(tmp_path: Path):
+@pytest_asyncio.fixture
+async def control_path_for_localhost(tmp_path: Path):
+    """The `control_path` parameter of `RemoteV2` for connecting to localhost."""
     control_path = tmp_path / "socketfile"
-    remote = RemoteV2("localhost", control_path=control_path)
-    assert control_path.exists()
-    files = remote.get_output(f"ls {control_path.parent}").split()
-    assert files == [control_path.name]
+    try:
+        yield control_path
+    finally:
+        if control_path.exists():
+            await LocalV2.run_async(
+                (
+                    "ssh",
+                    f"-oControlPath={control_path}",
+                    "-O",
+                    "exit",
+                    "localhost",
+                ),
+            )
+            assert not control_path.exists()
 
 
-@requires_ssh_to_localhost
-def test_init_with_none_controlpath(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    control_path = tmp_path / "socketfile"
+@pytest.fixture
+def mock_get_controlpath_for(
+    monkeypatch: pytest.MonkeyPatch, control_path_for_localhost: Path
+):
+    """Mock of `get_controlpath_for` so it returns the control path we want to use."""
     mock_get_controlpath_for = Mock(
-        wraps=get_controlpath_for, return_value=control_path
+        wraps=get_controlpath_for, return_value=control_path_for_localhost
     )
-
     monkeypatch.setattr(
         milatools.utils.remote_v2,
         get_controlpath_for.__name__,
         mock_get_controlpath_for,
     )
-    remote = RemoteV2("localhost", control_path=None)
-    mock_get_controlpath_for.assert_called_once_with("localhost")
-    assert control_path.exists()
-    files = remote.get_output(f"ls {control_path.parent}").split()
-    assert files == [control_path.name]
+    return mock_get_controlpath_for
 
 
-@pytest.mark.parametrize(
-    "hostname",
-    [
-        pytest.param("localhost", marks=requires_ssh_to_localhost),
-        skip_param_if_not_already_logged_in("mila"),
-        skip_param_if_not_already_logged_in("narval"),
-        skip_param_if_not_already_logged_in("beluga"),
-        skip_param_if_not_already_logged_in("cedar"),
-        skip_param_if_not_already_logged_in("graham"),
-        skip_param_if_not_already_logged_in("niagara"),
-    ],
-)
-def test_run(hostname: str):
-    command = "echo Hello World"
-    remote = RemoteV2(hostname)
-    output = remote.get_output(command)
-    assert output == "Hello World"
+@pytest.fixture(params=[True, False])
+def already_logged_in_to_localhost(
+    request: pytest.FixtureRequest,
+    control_path_for_localhost: Path,
+):
+    """Fixture that makes the setup as if we are/aren't already logged in to `localhost`
+    via SSH with a control socket."""
+    expected_to_be_logged_in: bool = request.param
+    assert not control_path_for_localhost.exists()
+
+    if expected_to_be_logged_in:
+        # manually setup the control socket to `localhost`.
+        LocalV2.run(
+            (
+                "ssh",
+                f"-oControlPath={control_path_for_localhost}",
+                "-oControlMaster=auto",
+                "-oControlPersist=60",
+                "localhost",
+            ),
+        )
+        assert control_path_for_localhost.exists()
+
+    yield expected_to_be_logged_in
 
 
-# NOTE: The timeout here is a part of the test: if we are already connected, running the
-# command should be fast, and if we aren't connected, this should be able to tell fast
-# (in other words, it shouldn't wait for 2FA input or similar).
-@pytest.mark.timeout(1, func_only=True)
-@pytest.mark.parametrize("also_run_command_to_check", [False, True])
-def test_is_already_logged_in(
-    cluster: str, already_logged_in: bool, also_run_command_to_check: bool
+class TestRemoteV2(RunnerTests):
+    """Tests for RemoteV2.
+
+    The tests for the `run`/`run_async`/etc. methods are in the base class, we just
+    supply the necessary fixtures here.
+    """
+
+    @pytest.fixture(scope="class")
+    def runner(self, cluster: str):
+        # Fixture that creates the runner used in the tests for run/run_async in the
+        # base class.
+        return RemoteV2(cluster)
+
+    @requires_ssh_to_localhost
+    @pytest.mark.parametrize("use_async_init", [False, True], ids=["sync", "async"])
+    @pytest.mark.asyncio
+    async def test_init_with_controlpath(
+        self,
+        control_path_for_localhost: Path,
+        use_async_init: bool,
+        ssh_config_file: Path,
+    ):
+        hostname = "localhost"
+        remote = (
+            (
+                await RemoteV2.connect(
+                    hostname,
+                    control_path=control_path_for_localhost,
+                    ssh_config_path=ssh_config_file,
+                )
+            )
+            if use_async_init
+            else RemoteV2(
+                hostname,
+                control_path=control_path_for_localhost,
+                ssh_config_path=ssh_config_file,
+            )
+        )
+        assert remote.control_path == control_path_for_localhost
+        assert control_path_for_localhost.exists()
+
+    @requires_ssh_to_localhost
+    @pytest.mark.parametrize("use_async_init", [False, True], ids=["sync", "async"])
+    @pytest.mark.asyncio
+    async def test_init_with_none_controlpath(
+        self,
+        use_async_init: bool,
+        control_path_for_localhost: Path,
+        ssh_config_file: Path,
+        mock_get_controlpath_for: Mock,
+    ):
+        """Checks that creating a `RemoteV2` with `control_path=None` calls
+        `get_controlpath_for`."""
+        hostname = "localhost"
+        remote = (
+            (
+                await RemoteV2.connect(
+                    hostname, control_path=None, ssh_config_path=ssh_config_file
+                )
+            )
+            if use_async_init
+            else RemoteV2(hostname, control_path=None, ssh_config_path=ssh_config_file)
+        )
+        mock_get_controlpath_for.assert_called_once()
+        assert remote.control_path == control_path_for_localhost
+        assert control_path_for_localhost.exists()
+
+
+@requires_ssh_to_localhost
+@pytest.mark.asyncio
+async def test_is_already_logged_in(
+    already_logged_in_to_localhost: bool,
+    mock_get_controlpath_for: Mock,
+):
+    assert is_already_logged_in("localhost") == already_logged_in_to_localhost
+    mock_get_controlpath_for.assert_called_once()
+
+
+@requires_ssh_to_localhost
+def test_controlsocket_is_running(
+    already_logged_in_to_localhost: bool, control_path_for_localhost: Path
 ):
     assert (
-        is_already_logged_in(
-            cluster, also_run_command_to_check=also_run_command_to_check
-        )
-        == already_logged_in
-        == get_controlpath_for(cluster).exists()
+        control_socket_is_running("localhost", control_path=control_path_for_localhost)
+        == already_logged_in_to_localhost
     )
 
 
-def test_controlsocket_is_running(cluster: str, already_logged_in: bool):
-    control_path = get_controlpath_for(cluster)
-    assert control_socket_is_running(cluster, control_path) == already_logged_in
+@requires_ssh_to_localhost
+@pytest.mark.asyncio
+async def test_controlsocket_is_running_async(
+    already_logged_in_to_localhost: bool, control_path_for_localhost: Path
+):
+    assert (
+        await control_socket_is_running_async(
+            "localhost", control_path=control_path_for_localhost
+        )
+        == already_logged_in_to_localhost
+    )

--- a/tests/utils/test_remote_v2.py
+++ b/tests/utils/test_remote_v2.py
@@ -7,6 +7,7 @@ import pytest
 import pytest_asyncio
 
 import milatools.utils.remote_v2
+from milatools.cli.utils import SSH_CONFIG_FILE
 from milatools.utils.local_v2 import LocalV2
 from milatools.utils.remote_v2 import (
     RemoteV2,
@@ -166,7 +167,10 @@ async def test_is_already_logged_in(
     already_logged_in_to_localhost: bool,
     mock_get_controlpath_for: Mock,
 ):
-    assert is_already_logged_in("localhost") == already_logged_in_to_localhost
+    assert (
+        is_already_logged_in("localhost", ssh_config_path=SSH_CONFIG_FILE)
+        == already_logged_in_to_localhost
+    )
     mock_get_controlpath_for.assert_called_once()
 
 

--- a/tests/utils/test_vscode_utils.py
+++ b/tests/utils/test_vscode_utils.py
@@ -36,7 +36,7 @@ from ..cli.common import (
     in_github_CI,
     in_self_hosted_github_CI,
     requires_ssh_to_localhost,
-    skip_if_on_github_CI,
+    skip_if_on_github_cloud_CI,
     xfails_on_windows,
 )
 
@@ -317,7 +317,7 @@ def test_extensions_to_install(
             "~/vscode",
             False,
             marks=[
-                skip_if_on_github_CI,
+                skip_if_on_github_cloud_CI,
                 requires_ssh_to_localhost,
                 requires_vscode,
             ],
@@ -327,7 +327,7 @@ def test_extensions_to_install(
             "~/.vscode-server",
             True,
             marks=[
-                skip_if_on_github_CI,
+                skip_if_on_github_cloud_CI,
                 skip_if_not_already_logged_in("mila"),
             ],
         ),


### PR DESCRIPTION
# What this does
This PR adds some new functions and classes which will be used in the near future to significantly refactor most commands of milatools.

Once these commands are made to use the content of this PR, they will:
- Properly support ssh keys with a passphrase
- Properly support clusters where 2FA is enabled (only goes through 2FA once)
- Resolve all paramiko issues
- Greatly reduce the connection latency for all commands that connect to the `mila` cluster (such as `mila code`).


### Highlights for reviewers (take a look at this first):
I would appreciate it if you could take a quick look at a few particular things, if you feel like it of course:
- LocalV2
    - the `run` function: https://github.com/lebrice/milatools/blob/add_computenode_localv2/milatools/utils/local_v2.py#L102
    - the `run_async` function: https://github.com/lebrice/milatools/blob/add_computenode_localv2/milatools/utils/local_v2.py#L102
- ComputeNode
    - the `salloc` function:  https://github.com/lebrice/milatools/blob/add_computenode_localv2/milatools/utils/compute_node.py#L278
    - the `sbatch` function:  https://github.com/lebrice/milatools/blob/add_computenode_localv2/milatools/utils/compute_node.py#L359
    - the `ComputeNode.run` method : https://github.com/lebrice/milatools/blob/add_computenode_localv2/milatools/utils/compute_node.py#L69

Here's a little class diagram illustrating the relationship between `Runner`, `LocalV2`, `RemoteV2`, and `ComputeNode`:

```mermaid
classDiagram
direction BT
class Runner
<<abstract>> Runner
class Runner{
    str hostname
    run(command) CompletedProcess
    run_async(command) CompletedProcess
    get_output(command) str
    get_output_async(command) str
}

LocalV2 --|> Runner : implements

class RemoteV2 {
    LocalV2 local_runner
    async connect(hostname) RemoteV2
}
RemoteV2 --|> Runner : implements

class ComputeNode {
    RemoteV2 login_node
    int job_id
    close()
}
ComputeNode --|> Runner : implements

```


Refactor:
- Adds `RemoteV2.connect`, an asynchronous constructor for connecting to a cluster;
- Adds async `salloc` and `sbatch` function that request ressources and return a `ComputeNode`
- Adds a `ComputeNode` class that can be used to run commands inside a job.
- Deprecate the use of `LocalV1`, `RemoteV1` and `SlurmRemote`: Code editors will show that using these is now discouraged. Importantly, this will NOT raise a warning to the user.