### PR TITLE
Tweak cli. add --sbatch and --salloc as alternatives to --alloc and --persist

### DIFF
--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -206,7 +206,17 @@ def add_arguments(parser: argparse.ArgumentParser):
         formatter_class=SortingHelpFormatter,
     )
     code_parser.add_argument(
-        "PATH", help="Path to open on the remote machine", type=str
+        "PATH",
+        help=(
+            "Path to open on the remote machine. Defaults to $HOME.\n"
+            "Can be a relative or absolute path. When a relative path (that doesn't "
+            "start with a '/', like foo/bar) is passed, the path is relative to the "
+            "$HOME directory on the selected cluster.\n"
+            "For example, foo/project will be interpreted as $HOME/foo/project."
+        ),
+        type=str,
+        default=".",
+        nargs="?",
     )
     code_parser.add_argument(
         "--cluster",

--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -242,10 +242,10 @@ def add_arguments(parser: argparse.ArgumentParser):
     )
     code_parser.add_argument(
         "--job",
-        type=str,
+        type=int,
         default=None,
         help="Job ID to connect to",
-        metavar="VALUE",
+        metavar="JOB_ID",
     )
     code_parser.add_argument(
         "--node",
@@ -563,7 +563,7 @@ def code(
     path: str,
     command: str,
     persist: bool,
-    job: str | None,
+    job: int | None,
     node: str | None,
     alloc: list[str],
     cluster: Cluster = "mila",
@@ -801,7 +801,7 @@ class StandardServerArgs(TypedDict):
     alloc: list[str]
     """Extra options to pass to slurm."""
 
-    job: str | None
+    job: int | None
     """Job ID to connect to."""
 
     name: str | None
@@ -954,10 +954,10 @@ def _add_standard_server_args(parser: ArgumentParser):
     )
     parser.add_argument(
         "--job",
-        type=str,
+        type=int,
         default=None,
         help="Job ID to connect to",
-        metavar="VALUE",
+        metavar="JOB_ID",
     )
     parser.add_argument(
         "--name",
@@ -1005,7 +1005,7 @@ def _standard_server(
     port: int | None,
     name: str | None,
     node: str | None,
-    job: str | None,
+    job: int | None,
     alloc: list[str],
     port_pattern=None,
     token_pattern=None,
@@ -1290,7 +1290,7 @@ def check_disk_quota(remote: Remote | RemoteV2) -> None:
 def _find_allocation(
     remote: Remote,
     node: str | None,
-    job: str | None,
+    job: int | str | None,
     alloc: list[str],
     cluster: Cluster = "mila",
     job_name: str = "mila-tools",

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -63,7 +63,7 @@ def test_help(
     [
         "mila",  # Error: Missing a subcommand.
         "mila search conda",
-        "mila code",  # Error: Missing the required PATH argument.
+        "mila code --boo",  # Error: Unknown argument.
         "mila serve",  # Error: Missing the subcommand.
         "mila forward",  # Error: Missing the REMOTE argument.
     ],

--- a/tests/cli/test_commands/test_help_mila_code_.txt
+++ b/tests/cli/test_commands/test_help_mila_code_.txt
@@ -1,18 +1,33 @@
 usage: mila code [-h] [--cluster {mila,cedar,narval,beluga,graham}]
-                 [--alloc ...] [--command VALUE] [--job VALUE] [--node VALUE]
-                 [--persist]
-                 PATH
+                 [--command VALUE] [--job JOB_ID] [--node NODE] [--persist]
+                 [--alloc ...] [--salloc ...] [--sbatch ...]
+                 [PATH]
 
 positional arguments:
-  PATH                  Path to open on the remote machine
+  PATH                  Path to open on the remote machine. Defaults to $HOME.
+                        Can be a relative or absolute path. When a relative
+                        path (that doesn't start with a '/', like foo/bar) is
+                        passed, the path is relative to the $HOME directory on
+                        the selected cluster. For example, foo/project will be
+                        interpreted as $HOME/foo/project.
 
 optional arguments:
   -h, --help            show this help message and exit
-  --alloc ...           Extra options to pass to slurm
   --cluster {mila,cedar,narval,beluga,graham}
                         Which cluster to connect to.
   --command VALUE       Command to use to start vscode (defaults to "code" or
                         the value of $MILATOOLS_CODE_COMMAND)
-  --job VALUE           Job ID to connect to
-  --node VALUE          Node to connect to
-  --persist             Whether the server should persist or not
+  --job JOB_ID          Job ID to connect to
+  --node NODE           Node to connect to
+
+Allocation optional arguments:
+  Extra options to pass to slurm.
+
+  --persist             Whether the server should persist or not when using
+                        --alloc
+  --alloc ...           Extra options to pass to salloc or to sbatch if
+                        --persist is set.
+  --salloc ...          Extra options to pass to salloc. Same as using --alloc
+                        without --persist.
+  --sbatch ...          Extra options to pass to sbatch. Same as using --alloc
+                        with --persist.

--- a/tests/cli/test_commands/test_help_mila_serve_aim_.txt
+++ b/tests/cli/test_commands/test_help_mila_serve_aim_.txt
@@ -1,6 +1,6 @@
-usage: mila serve aim [-h] [--alloc ...] [--job VALUE] [--name VALUE]
-                      [--node VALUE] [--persist] [--port VALUE]
-                      [--profile VALUE]
+usage: mila serve aim [-h] [--job JOB_ID] [--name VALUE] [--node VALUE]
+                      [--port VALUE] [--profile VALUE] [--persist]
+                      [--alloc ...] [--salloc ...] [--sbatch ...]
                       LOGDIR
 
 positional arguments:
@@ -8,10 +8,19 @@ positional arguments:
 
 optional arguments:
   -h, --help       show this help message and exit
-  --alloc ...      Extra options to pass to slurm
-  --job VALUE      Job ID to connect to
+  --job JOB_ID     Job ID to connect to
   --name VALUE     Name of the persistent server
   --node VALUE     Node to connect to
-  --persist        Whether the server should persist or not
   --port VALUE     Port to open on the local machine
   --profile VALUE  Name of the profile to use
+
+Allocation optional arguments:
+  Extra options to pass to slurm.
+
+  --persist        Whether the server should persist or not when using --alloc
+  --alloc ...      Extra options to pass to salloc or to sbatch if --persist
+                   is set.
+  --salloc ...     Extra options to pass to salloc. Same as using --alloc
+                   without --persist.
+  --sbatch ...     Extra options to pass to sbatch. Same as using --alloc with
+                   --persist.

--- a/tests/cli/test_commands/test_help_mila_serve_lab_.txt
+++ b/tests/cli/test_commands/test_help_mila_serve_lab_.txt
@@ -1,6 +1,6 @@
-usage: mila serve lab [-h] [--alloc ...] [--job VALUE] [--name VALUE]
-                      [--node VALUE] [--persist] [--port VALUE]
-                      [--profile VALUE]
+usage: mila serve lab [-h] [--job JOB_ID] [--name VALUE] [--node VALUE]
+                      [--port VALUE] [--profile VALUE] [--persist]
+                      [--alloc ...] [--salloc ...] [--sbatch ...]
                       [PATH]
 
 positional arguments:
@@ -8,10 +8,19 @@ positional arguments:
 
 optional arguments:
   -h, --help       show this help message and exit
-  --alloc ...      Extra options to pass to slurm
-  --job VALUE      Job ID to connect to
+  --job JOB_ID     Job ID to connect to
   --name VALUE     Name of the persistent server
   --node VALUE     Node to connect to
-  --persist        Whether the server should persist or not
   --port VALUE     Port to open on the local machine
   --profile VALUE  Name of the profile to use
+
+Allocation optional arguments:
+  Extra options to pass to slurm.
+
+  --persist        Whether the server should persist or not when using --alloc
+  --alloc ...      Extra options to pass to salloc or to sbatch if --persist
+                   is set.
+  --salloc ...     Extra options to pass to salloc. Same as using --alloc
+                   without --persist.
+  --sbatch ...     Extra options to pass to sbatch. Same as using --alloc with
+                   --persist.

--- a/tests/cli/test_commands/test_help_mila_serve_mlflow_.txt
+++ b/tests/cli/test_commands/test_help_mila_serve_mlflow_.txt
@@ -1,6 +1,6 @@
-usage: mila serve mlflow [-h] [--alloc ...] [--job VALUE] [--name VALUE]
-                         [--node VALUE] [--persist] [--port VALUE]
-                         [--profile VALUE]
+usage: mila serve mlflow [-h] [--job JOB_ID] [--name VALUE] [--node VALUE]
+                         [--port VALUE] [--profile VALUE] [--persist]
+                         [--alloc ...] [--salloc ...] [--sbatch ...]
                          LOGDIR
 
 positional arguments:
@@ -8,10 +8,19 @@ positional arguments:
 
 optional arguments:
   -h, --help       show this help message and exit
-  --alloc ...      Extra options to pass to slurm
-  --job VALUE      Job ID to connect to
+  --job JOB_ID     Job ID to connect to
   --name VALUE     Name of the persistent server
   --node VALUE     Node to connect to
-  --persist        Whether the server should persist or not
   --port VALUE     Port to open on the local machine
   --profile VALUE  Name of the profile to use
+
+Allocation optional arguments:
+  Extra options to pass to slurm.
+
+  --persist        Whether the server should persist or not when using --alloc
+  --alloc ...      Extra options to pass to salloc or to sbatch if --persist
+                   is set.
+  --salloc ...     Extra options to pass to salloc. Same as using --alloc
+                   without --persist.
+  --sbatch ...     Extra options to pass to sbatch. Same as using --alloc with
+                   --persist.

--- a/tests/cli/test_commands/test_help_mila_serve_notebook_.txt
+++ b/tests/cli/test_commands/test_help_mila_serve_notebook_.txt
@@ -1,6 +1,6 @@
-usage: mila serve notebook [-h] [--alloc ...] [--job VALUE] [--name VALUE]
-                           [--node VALUE] [--persist] [--port VALUE]
-                           [--profile VALUE]
+usage: mila serve notebook [-h] [--job JOB_ID] [--name VALUE] [--node VALUE]
+                           [--port VALUE] [--profile VALUE] [--persist]
+                           [--alloc ...] [--salloc ...] [--sbatch ...]
                            [PATH]
 
 positional arguments:
@@ -8,10 +8,19 @@ positional arguments:
 
 optional arguments:
   -h, --help       show this help message and exit
-  --alloc ...      Extra options to pass to slurm
-  --job VALUE      Job ID to connect to
+  --job JOB_ID     Job ID to connect to
   --name VALUE     Name of the persistent server
   --node VALUE     Node to connect to
-  --persist        Whether the server should persist or not
   --port VALUE     Port to open on the local machine
   --profile VALUE  Name of the profile to use
+
+Allocation optional arguments:
+  Extra options to pass to slurm.
+
+  --persist        Whether the server should persist or not when using --alloc
+  --alloc ...      Extra options to pass to salloc or to sbatch if --persist
+                   is set.
+  --salloc ...     Extra options to pass to salloc. Same as using --alloc
+                   without --persist.
+  --sbatch ...     Extra options to pass to sbatch. Same as using --alloc with
+                   --persist.

--- a/tests/cli/test_commands/test_help_mila_serve_tensorboard_.txt
+++ b/tests/cli/test_commands/test_help_mila_serve_tensorboard_.txt
@@ -1,6 +1,7 @@
-usage: mila serve tensorboard [-h] [--alloc ...] [--job VALUE] [--name VALUE]
-                              [--node VALUE] [--persist] [--port VALUE]
-                              [--profile VALUE]
+usage: mila serve tensorboard [-h] [--job JOB_ID] [--name VALUE]
+                              [--node VALUE] [--port VALUE] [--profile VALUE]
+                              [--persist] [--alloc ...] [--salloc ...]
+                              [--sbatch ...]
                               LOGDIR
 
 positional arguments:
@@ -8,10 +9,19 @@ positional arguments:
 
 optional arguments:
   -h, --help       show this help message and exit
-  --alloc ...      Extra options to pass to slurm
-  --job VALUE      Job ID to connect to
+  --job JOB_ID     Job ID to connect to
   --name VALUE     Name of the persistent server
   --node VALUE     Node to connect to
-  --persist        Whether the server should persist or not
   --port VALUE     Port to open on the local machine
   --profile VALUE  Name of the profile to use
+
+Allocation optional arguments:
+  Extra options to pass to slurm.
+
+  --persist        Whether the server should persist or not when using --alloc
+  --alloc ...      Extra options to pass to salloc or to sbatch if --persist
+                   is set.
+  --salloc ...     Extra options to pass to salloc. Same as using --alloc
+                   without --persist.
+  --sbatch ...     Extra options to pass to sbatch. Same as using --alloc with
+                   --persist.

--- a/tests/cli/test_commands/test_invalid_command_output_mila_code___boo_.txt
+++ b/tests/cli/test_commands/test_invalid_command_output_mila_code___boo_.txt
@@ -1,0 +1,3 @@
+usage: mila [-h] [--version] [-v]
+            {docs,intranet,init,forward,code,sync,serve} ...
+mila: error: unrecognized arguments: --boo


### PR DESCRIPTION
- Adds a --salloc flag which is exaclty the same as using the '--alloc' flag (without the --persist) flag.
- Adds a --sbatch flag which is the same as doing --persist --alloc ...

I think these are more naturally understood as the argument that are passed to `salloc` and `sbatch` respectively.

Also, these two new args are in a mutually exclusive group with --persist.