### PR TITLE
Tweak build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Store coverage report as an artifact
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-reports
+        name: coverage-reports-unit-${{ matrix.platform }}-${{ matrix.python-version }}
         path: ./coverage.xml
 
   mock-slurm-integration-tests:
@@ -150,7 +150,7 @@ jobs:
       - name: Store coverage report as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-reports
+          name: coverage-reports-mock-${{ matrix.platform }}-${{ matrix.python-version }}
           path: ./coverage.xml
 
   real-slurm-integration-tests:
@@ -182,9 +182,11 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: coverage-reports
+          pattern: coverage-reports-*
+          merge-multiple: false
+          # download all the artifacts in this directory (each .coverage.xml will be in a subdirectory)
+          # Next step if this doesn't work would be to give the coverage files a unique name and use merge-multiple: true
           path: coverage_reports
-          # merge-multiple: false
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       run: poetry run pytest --cov=milatools --cov-report=xml --cov-append
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4.3.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
@@ -152,7 +152,7 @@ jobs:
           SLURM_CLUSTER: localhost
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4.3.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,15 +77,11 @@ jobs:
     - name: Test with pytest
       run: poetry run pytest --cov=milatools --cov-report=xml --cov-append
 
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4.3.1
+    - name: Store coverage report as an artifact
+      uses: actions/upload-artifact@v2
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests
-        env_vars: PLATFORM,PYTHON
-        name: codecov-umbrella
-        fail_ci_if_error: false
+        name: coverage-reports
+        path: ./coverage.xml
 
   mock-slurm-integration-tests:
     name: integration tests with a mock slurm cluster
@@ -151,15 +147,11 @@ jobs:
         env:
           SLURM_CLUSTER: localhost
 
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.3.1
+      - name: Store coverage report as an artifact
+        uses: actions/upload-artifact@v2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          flags: integrationtests
-          env_vars: PLATFORM,PYTHON
-          name: codecov-umbrella
-          fail_ci_if_error: false
+          name: coverage-reports
+          path: ./coverage.xml
 
   real-slurm-integration-tests:
 
@@ -178,5 +170,23 @@ jobs:
       cluster: ${{ matrix.cluster }}
       python-version: ${{ matrix.python-version }}
       timeout-minutes: 30
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # https://about.codecov.io/blog/uploading-code-coverage-in-a-separate-job-on-github-actions/
+  upload-coverage-codecov:
+    needs: [real-slurm-integration-tests]
+    runs-on: ubuntu-latest
+    name: Upload coverage reports to Codecov
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # file: ./coverage.xml  # Search for all coverage files from each workflow.
+          # flags: integrationtests
+          # env_vars: PLATFORM,PYTHON
+          # name: codecov-umbrella
+          fail_ci_if_error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       run: poetry run pytest --cov=milatools --cov-report=xml --cov-append
 
     - name: Store coverage report as an artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-reports
         path: ./coverage.xml
@@ -148,7 +148,7 @@ jobs:
           SLURM_CLUSTER: localhost
 
       - name: Store coverage report as an artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-reports
           path: ./coverage.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,20 @@
 name: Python package
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+
+# https://stackoverflow.com/a/72408109/6388696
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-to-cancel-any-in-progress-job-or-run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linting:
@@ -133,7 +147,7 @@ jobs:
 
       - name: Launch integration tests
         run: poetry run pytest --slow --cov=milatools --cov-report=xml --cov-append -vvv --log-level=DEBUG
-        timeout-minutes: 5
+        timeout-minutes: 15
         env:
           SLURM_CLUSTER: localhost
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Download artifacts
         uses: actions/download-artifact@v4
+        with:
+          name: coverage-reports
+          path: coverage_reports
+          # merge-multiple: false
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -189,4 +193,5 @@ jobs:
           # flags: integrationtests
           # env_vars: PLATFORM,PYTHON
           # name: codecov-umbrella
+          directory: coverage_reports
           fail_ci_if_error: true

--- a/.github/workflows/full_cluster_tests.yml
+++ b/.github/workflows/full_cluster_tests.yml
@@ -27,5 +27,22 @@ jobs:
       cluster: ${{ matrix.cluster }}
       python-version: ${{ matrix.python-version }}
       timeout-minutes: 60
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  # https://about.codecov.io/blog/uploading-code-coverage-in-a-separate-job-on-github-actions/
+  upload-coverage-codecov:
+    needs: [real-slurm-integration-tests]
+    runs-on: ubuntu-latest
+    name: Upload coverage reports to Codecov
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # file: ./coverage.xml  # Search for all coverage files from each workflow.
+          flags: integrationtests
+          # env_vars: PLATFORM,PYTHON
+          # name: codecov-umbrella
+          fail_ci_if_error: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,9 +12,6 @@ on:
         required: false
         type: number
         default: 30
-    secrets:
-      CODECOV_TOKEN:
-        required: true
 
   workflow_dispatch:
 
@@ -53,12 +50,8 @@ jobs:
         env:
           SLURM_CLUSTER: ${{ inputs.cluster }}
 
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Store coverage report as an artifact
+        uses: actions/upload-artifact@v2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          flags: integrationtests
-          env_vars: PLATFORM,PYTHON
-          name: codecov-umbrella
-          fail_ci_if_error: false
+          name: coverage-reports
+          path: ./coverage.xml

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,5 +53,5 @@ jobs:
       - name: Store coverage report as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-reports
+          name: coverage-reports-integration-${{ inputs.cluster }}-${{ inputs.python-version }}
           path: ./coverage.xml

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -51,7 +51,7 @@ jobs:
           SLURM_CLUSTER: ${{ inputs.cluster }}
 
       - name: Store coverage report as an artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-reports
           path: ./coverage.xml


### PR DESCRIPTION
- Make it so the build workflow doesn't run on changes to the README (as is the case in #122 )
- The build workflow will now have a concurrency setting to cancel previous workflow runs on a push to the same branch.
- Pass the codecov token explicitly to fix issues with codecov upload step
- Increase the length allowed for integration tests