### PR TITLE
Fix copying of SSH keys from WSL to Windows

### DIFF
--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -34,7 +34,6 @@ from typing_extensions import TypedDict, deprecated
 from milatools.cli import console
 from milatools.cli.code import code
 from milatools.cli.init_command import (
-    copy_wsl_ssh_keys_to_windows_ssh_folder,
     print_welcome_message,
     setup_keys_on_login_node,
     setup_passwordless_ssh_access,
@@ -530,8 +529,6 @@ def init():
     # the Windows side.
     if running_inside_WSL():
         setup_windows_ssh_config_from_wsl(linux_ssh_config=ssh_config)
-        # if running inside WSL, copy the keys to the Windows folder.
-        copy_wsl_ssh_keys_to_windows_ssh_folder()
 
     setup_keys_on_login_node()
     setup_vscode_settings()

--- a/milatools/cli/commands.py
+++ b/milatools/cli/commands.py
@@ -34,6 +34,7 @@ from typing_extensions import TypedDict, deprecated
 from milatools.cli import console
 from milatools.cli.code import code
 from milatools.cli.init_command import (
+    copy_wsl_ssh_keys_to_windows_ssh_folder,
     print_welcome_message,
     setup_keys_on_login_node,
     setup_passwordless_ssh_access,
@@ -519,16 +520,19 @@ def init():
 
     ssh_config = setup_ssh_config()
 
+    success = setup_passwordless_ssh_access(ssh_config=ssh_config)
+    if not success:
+        exit()
+
     # if we're running on WSL, we actually just copy the id_rsa + id_rsa.pub and the
     # ~/.ssh/config to the Windows ssh directory (taking care to remove the
     # ControlMaster-related entries) so that the user doesn't need to install Python on
     # the Windows side.
     if running_inside_WSL():
         setup_windows_ssh_config_from_wsl(linux_ssh_config=ssh_config)
+        # if running inside WSL, copy the keys to the Windows folder.
+        copy_wsl_ssh_keys_to_windows_ssh_folder()
 
-    success = setup_passwordless_ssh_access(ssh_config=ssh_config)
-    if not success:
-        exit()
     setup_keys_on_login_node()
     setup_vscode_settings()
     print_welcome_message()

--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -427,6 +427,8 @@ def print_welcome_message():
 
 
 def _copy_if_needed(linux_key_file: Path, windows_key_file: Path):
+    print(f"Checking if {linux_key_file} exists: {linux_key_file.exists()}")
+    print(f"Checking if {windows_key_file} exists: {windows_key_file.exists()}")
     if linux_key_file.exists() and not windows_key_file.exists():
         print(
             f"Copying {linux_key_file} over to the Windows ssh folder at "

--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -438,13 +438,11 @@ def _copy_if_needed(linux_key_file: Path, windows_key_file: Path):
         )
         shutil.copy2(src=linux_key_file, dst=windows_key_file)
 
-
 @functools.lru_cache()
 def get_windows_home_path_in_wsl() -> Path:
     assert running_inside_WSL()
-    windows_username = subprocess.getoutput("powershell.exe '$env:HomePath'").strip()
-    windows_username = windows_username.replace('\\', '/')
-    return Path(f"/mnt/c/{windows_username}")
+    windows_username = subprocess.getoutput("powershell.exe '$env:UserName'").strip()
+    return Path(f"/mnt/c/Users/{windows_username}")
 
 
 def create_ssh_keypair(

--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -216,7 +216,11 @@ def setup_windows_ssh_config_from_wsl(linux_ssh_config: SSHConfig):
     assert running_inside_WSL()
     windows_home = get_windows_home_path_in_wsl()
     linux_private_key_file = (
-        Path(linux_ssh_config.host("mila").get("identityfile", "~/.ssh/id_rsa"))
+        Path(
+            linux_ssh_config.host("mila").get(
+                "identityfile", Path.home() / ".ssh/id_rsa"
+            )
+        )
         .expanduser()
         .resolve()
     )

--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -174,25 +174,6 @@ def setup_ssh_config(
     return ssh_config
 
 
-def copy_wsl_ssh_keys_to_windows_ssh_folder():
-    """Copy the SSH key to the windows folder so that passwordless SSH also works on
-    Windows."""
-    assert running_inside_WSL()
-    # TODO: Get the key to copy from the SSH config instead of assuming ~/.ssh/id_rsa.
-    windows_home = get_windows_home_path_in_wsl()
-    linux_private_key_file = Path.home() / ".ssh/id_rsa"
-    windows_private_key_file = windows_home / ".ssh/id_rsa"
-
-    for linux_key_file, windows_key_file in [
-        (linux_private_key_file, windows_private_key_file),
-        (
-            linux_private_key_file.with_suffix(".pub"),
-            windows_private_key_file.with_suffix(".pub"),
-        ),
-    ]:
-        _copy_if_needed(linux_key_file, windows_key_file)
-
-
 def setup_windows_ssh_config_from_wsl(linux_ssh_config: SSHConfig):
     """Setup the Windows SSH configuration and public key from within WSL.
 
@@ -228,6 +209,24 @@ def setup_windows_ssh_config_from_wsl(linux_ssh_config: SSHConfig):
         windows_ssh_config.save()
     else:
         print(f"Did not change ssh config at path {windows_ssh_config.path}")
+
+    # if running inside WSL, copy the keys to the Windows folder.
+    # Copy the SSH key to the windows folder so that passwordless SSH also works on
+    # Windows.
+    assert running_inside_WSL()
+    # TODO: Get the key to copy from the SSH config instead of assuming ~/.ssh/id_rsa.
+    windows_home = get_windows_home_path_in_wsl()
+    linux_private_key_file = Path.home() / ".ssh/id_rsa"
+    windows_private_key_file = windows_home / ".ssh/id_rsa"
+
+    for linux_key_file, windows_key_file in [
+        (linux_private_key_file, windows_private_key_file),
+        (
+            linux_private_key_file.with_suffix(".pub"),
+            windows_private_key_file.with_suffix(".pub"),
+        ),
+    ]:
+        _copy_if_needed(linux_key_file, windows_key_file)
 
 
 def setup_passwordless_ssh_access(ssh_config: SSHConfig) -> bool:

--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -173,6 +173,7 @@ def setup_ssh_config(
         print(f"Wrote {ssh_config_path}")
     return ssh_config
 
+
 def _maybe_copy_keys():
     if not running_inside_WSL():
         return None
@@ -192,6 +193,7 @@ def _maybe_copy_keys():
         ),
     ]:
         _copy_if_needed(linux_key_file, windows_key_file)
+
 
 def setup_windows_ssh_config_from_wsl(linux_ssh_config: SSHConfig):
     """Setup the Windows SSH configuration and public key from within WSL.
@@ -257,7 +259,7 @@ def setup_passwordless_ssh_access(ssh_config: SSHConfig) -> bool:
     # TODO: This uses the public key set in the SSH config file, which may (or may not)
     # be the random id*.pub file that was just checked for above.
     success = setup_passwordless_ssh_access_to_cluster("mila")
-    _maybe_copy_keys() # if running inside WSL, copy the keys to the Windows folder.
+    _maybe_copy_keys()  # if running inside WSL, copy the keys to the Windows folder.
     if not success:
         return False
     setup_keys_on_login_node("mila")
@@ -438,7 +440,8 @@ def _copy_if_needed(linux_key_file: Path, windows_key_file: Path):
         )
         shutil.copy2(src=linux_key_file, dst=windows_key_file)
 
-@functools.lru_cache()
+
+@functools.lru_cache
 def get_windows_home_path_in_wsl() -> Path:
     assert running_inside_WSL()
     windows_username = subprocess.getoutput("powershell.exe '$env:UserName'").strip()

--- a/milatools/cli/init_command.py
+++ b/milatools/cli/init_command.py
@@ -435,10 +435,16 @@ def _copy_if_needed(linux_key_file: Path, windows_key_file: Path):
         shutil.copy2(src=linux_key_file, dst=windows_key_file)
 
 
+# def get_windows_home_path_in_wsl() -> Path:
+#     assert running_inside_WSL()
+#     windows_username = subprocess.getoutput("powershell.exe '$env:UserName'").strip()
+#     return Path(f"/mnt/c/Users/{windows_username}")
+
 def get_windows_home_path_in_wsl() -> Path:
     assert running_inside_WSL()
-    windows_username = subprocess.getoutput("powershell.exe '$env:UserName'").strip()
-    return Path(f"/mnt/c/Users/{windows_username}")
+    windows_username = subprocess.getoutput("powershell.exe '$env:HomePath'").strip()
+    windows_username = windows_username.replace('\\', '/')
+    return Path(f"/mnt/c/{windows_username}")
 
 
 def create_ssh_keypair(

--- a/tests/cli/test_code.py
+++ b/tests/cli/test_code.py
@@ -10,31 +10,8 @@ import pytest
 
 import milatools.cli.code
 import milatools.cli.utils
-from milatools.cli.utils import running_inside_WSL
 from milatools.utils.compute_node import ComputeNode
 from milatools.utils.local_v2 import LocalV2
-
-
-@pytest.fixture
-def pretend_to_be_in_WSL(
-    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
-):
-    # By default, pretend to be in WSL. Indirect parametrization can be used to
-    # overwrite this value for a given test (as is done below).
-    in_wsl = getattr(request, "param", True)
-
-    _mock_running_inside_WSL = Mock(spec=running_inside_WSL, return_value=in_wsl)
-    monkeypatch.setattr(
-        milatools.cli.utils,
-        running_inside_WSL.__name__,  # type: ignore
-        _mock_running_inside_WSL,
-    )
-    monkeypatch.setattr(
-        milatools.cli.code,
-        running_inside_WSL.__name__,  # type: ignore
-        _mock_running_inside_WSL,
-    )
-    return in_wsl
 
 
 @pytest.mark.parametrize("pretend_to_be_in_WSL", [True, False], indirect=True)

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -832,13 +832,12 @@ def linux_ssh_config(
 
 @pytest.mark.parametrize("accept_changes", [True, False], ids=["accept", "reject"])
 def test_setup_windows_ssh_config_from_wsl(
-    tmp_path: Path,
-    pretend_to_be_in_WSL,
+    pretend_to_be_in_WSL,  # here even if `windows_home` already uses it (more explicit)
     windows_home: Path,
     linux_ssh_config: SSHConfig,
     input_pipe: PipeInput,
     file_regression: FileRegressionFixture,
-    monkeypatch: pytest.MonkeyPatch,
+    fake_linux_ssh_keypair: tuple[Path, Path],  # add this fixture so the keys exist.
     accept_changes: bool,
 ):
     initial_contents = linux_ssh_config.cfg.config()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -449,15 +449,21 @@ def pretend_to_be_in_WSL(
     in_wsl = getattr(request, "param", True)
     _mock_running_inside_WSL = Mock(spec=running_inside_WSL, return_value=in_wsl)
     monkeypatch.setattr(
-        milatools.cli.utils,
+        milatools.cli.utils,  # defined here
         running_inside_WSL.__name__,  # type: ignore
         _mock_running_inside_WSL,
     )
-    monkeypatch.setattr(
+    # Unfortunately we have to also patch this everywhere we import it in other modules.
+    for place_that_imports_it in [
         milatools.cli.code,
-        running_inside_WSL.__name__,  # type: ignore
-        _mock_running_inside_WSL,
-    )
+        milatools.cli.init_command,
+        milatools.cli.commands,
+    ]:
+        monkeypatch.setattr(
+            place_that_imports_it,
+            running_inside_WSL.__name__,  # type: ignore
+            _mock_running_inside_WSL,
+        )
 
     return in_wsl
 


### PR DESCRIPTION
When running in WSL, it looks like we are copying the `id_rsa` before creating them. In this PR, we check if we need to copy them after the creation. 

I am not sure what to do if the Windows ssh config file did not changed, should we still copy the `id_rsa` ? I am referring to this [line ](https://github.com/mila-iqia/milatools/blob/4ffdbaa92d6c1f7fb3c5249d0108d10b24653806/milatools/cli/init_command.py#L212)