### PR TITLE
Fix `milatools.cli.utils.batched` in python 3.12

### DIFF
--- a/milatools/cli/utils.py
+++ b/milatools/cli/utils.py
@@ -352,7 +352,8 @@ def batched(
     [('A', 'B', 'C'), ('D', 'E', 'F')]
     """
     if sys.version_info >= (3, 12) and not droplast:
-        return itertools.batched(iterable, n)
+        yield from itertools.batched(iterable, n)
+        return
     if n < 1:
         raise ValueError("n must be at least one")
     it = iter(iterable)


### PR DESCRIPTION
Fix a bug in the `milatools.cli.utils.batched` function in Python versions >= 3.12. 

This function is called by `milatools.utils.vscode_utils._find_code_server_executable` which itself is called by `mila code` indirectly.

This probably means that the `mila code` command was erroring out in Python 3.12 and above, but I'm not sure. 