### PR TITLE
Change strip to rstrip to remove common lustre output chars

### DIFF
--- a/milatools/utils/disk_quota.py
+++ b/milatools/utils/disk_quota.py
@@ -91,9 +91,9 @@ def _parse_lfs_quota_output(
         limit_files,
         _grace_files,
     ) = values_line_parts
-
-    used_gb = int(used_kbytes.strip()) / (1024**2)
-    max_gb = int(limit_kbytes.strip()) / (1024**2)
+    
+    used_gb = int(used_kbytes.rstrip('*Gk')) / (1024**2)
+    max_gb = int(limit_kbytes.rstrip('*Gk')) / (1024**2)
     used_files = int(files.strip())
     max_files = int(limit_files.strip())
     return (used_gb, max_gb), (used_files, max_files)


### PR DESCRIPTION
Earlier, I was getting the following warning when running 'mila code' with a full home folder. 
```
Checking disk quota on $HOME...                      disk_quota.py:30
[05/29/25 13:02:37] WARNING  Unable to check the disk-quota on the    code.py:81
                             mila cluster: invalid literal for int()            
                             with base 10: '104860428*'                         
```

As diagnosed by @obilaniu in the Mila slack:

```
==== HOME ====
Disk quotas for usr cesar.valdez (uid 1500000992):
     Filesystem    used   quota   limit   grace   files   quota   limit   grace
     /home/mila    100G*     0k    100G       -  870523       0 1048576       -
uid 1500000992 is using default block quota setting
uid 1500000992 is using default file quota setting

==== SCRATCH ====

Quota information for storage pool Default (ID: 1):

      user/group     ||           size          ||    chunk files    
     name     |  id  ||    used    |    hard    ||  used   |  hard   
--------------|------||------------|------------||---------|---------
  cesar.valdez|1500000992||    7.10 GiB|    5.00 TiB||    57285|unlimited
  ```

The allocation proceeds as normal and I'm able to otherwise log in.

To address the warning, I propose changing the current `.strip()` that's in for one that accounts for common lustre outputs where memory is concerned, such as `"Gk*"` in the `_parse_lfs_quota_output` at `milatools/utils/disk_quota.py`.