### PR TITLE
Fix issues in GitHub CI due to 2fa changes on Mila cluster

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,21 +34,11 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-        args: ['--fix']
+        args: ["--fix"]
         require_serial: true
       # Run the formatter.
       - id: ruff-format
         args: []
-
-  # python docstring formatting
-  - repo: https://github.com/myint/docformatter
-    rev: v1.7.5
-    hooks:
-      - id: docformatter
-        # https://github.com/PyCQA/docformatter/issues/172#issuecomment-1496443857
-        additional_dependencies: [tomli]
-        args: [--in-place]
-        require_serial: true
 
   # md formatting
   # NOTE: Disabling, since it wants to change the markdown regression files with escaped

--- a/tests/integration/test_code.py
+++ b/tests/integration/test_code.py
@@ -31,6 +31,7 @@ from milatools.utils.disk_quota import check_disk_quota, check_disk_quota_v1
 from milatools.utils.remote_v1 import RemoteV1
 from milatools.utils.remote_v2 import RemoteV2
 
+from ..cli.common import in_github_CI
 from ..conftest import job_name, launches_jobs
 from .test_slurm_remote import get_recent_jobs_info_dicts
 
@@ -296,7 +297,20 @@ doesnt_create_new_jobs = pytest.mark.usefixtures(
 
 
 @doesnt_create_new_jobs
-@pytest.mark.parametrize("use_v1", [False, True], ids=["code", "code_v1"])
+@pytest.mark.parametrize(
+    "use_v1",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                in_github_CI,
+                reason="Misbehaving since the 2FA changes on the Mila cluster.",
+            ),
+        ),
+    ],
+    ids=["code", "code_v1"],
+)
 @pytest.mark.parametrize(
     ("use_node_name", "use_job_id"),
     [(True, False), (False, True), (True, True)],

--- a/tests/integration/test_code.py
+++ b/tests/integration/test_code.py
@@ -32,7 +32,7 @@ from milatools.utils.remote_v1 import RemoteV1
 from milatools.utils.remote_v2 import RemoteV2
 
 from ..conftest import job_name, launches_jobs
-from .test_slurm_remote import PARAMIKO_SSH_BANNER_BUG, get_recent_jobs_info_dicts
+from .test_slurm_remote import get_recent_jobs_info_dicts
 
 logger = get_logger(__name__)
 
@@ -296,11 +296,7 @@ doesnt_create_new_jobs = pytest.mark.usefixtures(
 
 
 @doesnt_create_new_jobs
-@pytest.mark.parametrize(
-    "use_v1",
-    [False, pytest.param(True, marks=[PARAMIKO_SSH_BANNER_BUG])],
-    ids=["code", "code_v1"],
-)
+@pytest.mark.parametrize("use_v1", [False, True], ids=["code", "code_v1"])
 @pytest.mark.parametrize(
     ("use_node_name", "use_job_id"),
     [(True, False), (False, True), (True, True)],

--- a/tests/integration/test_code_v1.py
+++ b/tests/integration/test_code_v1.py
@@ -8,19 +8,24 @@ from logging import getLogger as get_logger
 import pytest
 
 from milatools.cli.commands import code_v1
-from milatools.cli.utils import get_hostname_to_use_for_compute_node
+from milatools.cli.utils import SSHConnectionError, get_hostname_to_use_for_compute_node
 from milatools.utils.remote_v1 import RemoteV1
 from milatools.utils.remote_v2 import RemoteV2
 
+from ..cli.common import in_github_CI
 from ..conftest import launches_jobs
-from .test_slurm_remote import PARAMIKO_SSH_BANNER_BUG, get_recent_jobs_info_dicts
+from .test_slurm_remote import get_recent_jobs_info_dicts
 
 logger = get_logger(__name__)
 
 
 @pytest.mark.slow
 @launches_jobs
-@PARAMIKO_SSH_BANNER_BUG
+@pytest.mark.xfail(
+    in_github_CI,
+    raises=SSHConnectionError,
+    reason="Misbehaving since the 2FA changes on the Mila cluster.",
+)
 @pytest.mark.parametrize("persist", [True, False])
 def test_code_v1(
     login_node: RemoteV1 | RemoteV2,

--- a/tests/integration/test_code_v1.py
+++ b/tests/integration/test_code_v1.py
@@ -8,7 +8,7 @@ from logging import getLogger as get_logger
 import pytest
 
 from milatools.cli.commands import code_v1
-from milatools.cli.utils import SSHConnectionError, get_hostname_to_use_for_compute_node
+from milatools.cli.utils import get_hostname_to_use_for_compute_node
 from milatools.utils.remote_v1 import RemoteV1
 from milatools.utils.remote_v2 import RemoteV2
 
@@ -21,9 +21,8 @@ logger = get_logger(__name__)
 
 @pytest.mark.slow
 @launches_jobs
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     in_github_CI,
-    raises=SSHConnectionError,
     reason="Misbehaving since the 2FA changes on the Mila cluster.",
 )
 @pytest.mark.parametrize("persist", [True, False])


### PR DESCRIPTION
- [x] Analyze the comment requesting `skipif` marks on `code_v1` test variants
- [x] Replace `xfail` with `skipif` in `test_code_v1.py` (skips the test entirely in GitHub CI instead of marking as expected failure)
- [x] Add `skipif` marks to `code_v1` parametrized variants in `test_code.py`'s `test_code_with_existing_job` test

<!-- START COPILOT CODING AGENT TIPS -->
---

⚡ Quickly spin up Copilot coding agent tasks from anywhere on your macOS or Windows machine with [Raycast](https://gh.io/cca-raycast-docs).
