### PR TITLE
Forward SLURM job environment variables to VS Code terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ The `--alloc` option may be used to pass extra arguments to `salloc` when alloca
 
 If you already have an allocation on a compute node, you may use the `--node NODENAME` or `--job JOBID` options to connect to that node.
 
+#### SLURM environment variables in VS Code terminals
+
+VS Code connects to the compute node in its own SSH session, outside of the SLURM job, so its terminals would normally only have `SLURM_JOB_ID` set (injected by the cluster when the session is adopted into the job) and none of the other `SLURM_*` variables (`SLURM_NTASKS`, `SLURM_TMPDIR`, etc.).
+
+To fix this, `mila code` saves the job's SLURM environment variables to a file (under `~/.cache/milatools/slurm_env/` on the cluster) when it creates the job, and installs a clearly-marked block in your `~/.bashrc` (and `~/.zshrc`, if you have one) on the cluster that restores them in VS Code terminals. The block is inert everywhere else: it only runs in sessions that have `SLURM_JOB_ID` but are missing the rest of the job's environment, and never overwrites variables in regular `salloc`/`srun` shells or job scripts.
+
+Known limitations: `fish` shells don't get the variables (the block is only installed for bash/zsh), and they are only available in the integrated terminals, not in the VS Code server process itself. Jobs connected to with `--job`/`--node` that weren't created by `mila code` don't have a saved environment.
+
 
 ### mila serve
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ VS Code connects to the compute node in its own SSH session, outside of the SLUR
 
 To fix this, `mila code` saves the job's SLURM environment variables to a file (under `~/.cache/milatools/slurm_env/` on the cluster) when it creates the job, and installs a clearly-marked block in your `~/.bashrc` (and `~/.zshrc`, if you have one) on the cluster that restores them in VS Code terminals. The block is inert everywhere else: it only runs in sessions that have `SLURM_JOB_ID` but are missing the rest of the job's environment, and never overwrites variables in regular `salloc`/`srun` shells or job scripts.
 
-Known limitations: `fish` shells don't get the variables (the block is only installed for bash/zsh), and they are only available in the integrated terminals, not in the VS Code server process itself. Jobs connected to with `--job`/`--node` that weren't created by `mila code` don't have a saved environment.
+`srun` run from these terminals behaves exactly like in an `salloc` shell, using the job's real allocation (task count, memory, etc.). `sbatch`, on the other hand, submits with a **clean environment**, as if run from a login shell: the restored `SLURM_*` variables are stripped for the submission only (they stay set in the terminal), so a job submitted from a terminal doesn't inherit stale settings from the job the terminal lives in — a classic source of confusing behavior when submitting from inside a job. Use `\sbatch` to bypass this and get plain `sbatch` behavior.
+
+Known limitations: `fish` shells don't get the variables (the block is only installed for bash/zsh), and they are only available in the integrated terminals, not in the VS Code server process itself. Jobs connected to with `--job`/`--node` that weren't created by `mila code` don't have a saved environment. The clean-`sbatch` wrapper is a shell function, so it doesn't apply in nested shells (e.g. `tmux`, running `bash`) or in scripts that call `sbatch` — those submit with the surrounding job's `SLURM_*` variables, exactly like in a real `salloc` session — and a user-defined `sbatch` alias shadows it.
 
 
 ### mila serve

--- a/milatools/cli/code.py
+++ b/milatools/cli/code.py
@@ -35,6 +35,7 @@ from milatools.utils.compute_node import ComputeNode, salloc, sbatch
 from milatools.utils.disk_quota import check_disk_quota
 from milatools.utils.local_v2 import LocalV2
 from milatools.utils.remote_v2 import RemoteV2
+from milatools.utils.slurm_env import setup_slurm_env_hook
 from milatools.utils.vscode_utils import sync_vscode_extensions
 
 logger = get_logger(__name__)
@@ -161,6 +162,11 @@ async def code(
             )
         job_name = "mila-code"
         alloc = alloc + [f"--job-name={job_name}"]
+
+        # Set up what's needed for VS Code terminals to get the SLURM env vars of the
+        # job. Done before creating the job, since the env dump script needs to be on
+        # the cluster when the job starts.
+        await setup_slurm_env_hook(login_node)
 
         if persist:
             compute_node_task = sbatch(

--- a/milatools/utils/compute_node.py
+++ b/milatools/utils/compute_node.py
@@ -17,6 +17,12 @@ from milatools.cli.utils import (
 from milatools.utils.remote_v1 import Hide
 from milatools.utils.remote_v2 import RemoteV2, logger, ssh_command
 from milatools.utils.runner import Runner
+from milatools.utils.slurm_env import (
+    DUMP_COMMAND,
+    remove_env_file,
+    remove_env_file_sync,
+    wait_for_env_file,
+)
 
 
 class JobNotRunningError(RuntimeError):
@@ -166,6 +172,7 @@ class ComputeNode(Runner):
             self.salloc_subprocess.terminate()
         else:
             self.login_node.run(f"scancel {self.job_id}")
+        remove_env_file_sync(self.login_node, self.job_id)
         self._closed = True
 
     async def close_async(self):
@@ -188,6 +195,7 @@ class ComputeNode(Runner):
                 hide=False,
                 warn=True,
             )
+        await remove_env_file(self.login_node, self.job_id)
         self._closed = True
 
 
@@ -326,6 +334,20 @@ async def salloc(
     # if it isn't true, an informative error will most probably be given to the user by
     # the first `ssh <cluster> srun --job-id <job_id>` command.
 
+    # Dump the SLURM env vars of the allocation to a per-job file by running the dump
+    # script from within the salloc shell (whose environment has the job's real task
+    # geometry, unlike a 1-task job step). VS Code terminals, whose SSH sessions are
+    # outside the job, source that file to recover the job's environment.
+    try:
+        assert salloc_subprocess.stdin is not None
+        salloc_subprocess.stdin.write(f"{DUMP_COMMAND}\n".encode())
+        await salloc_subprocess.stdin.drain()
+        await wait_for_env_file(login_node, job_id)
+    except Exception as err:
+        logger.warning(
+            f"Unable to save the SLURM environment variables of job {job_id}: {err}"
+        )
+
     # NOTE: passing the process handle to this ComputeNodeRemote so it doesn't go out of
     # scope and die (which would kill the interactive job).
     return ComputeNode(
@@ -351,10 +373,16 @@ async def sbatch(
     # home directory, so no harm done.
     # Also, should we use --ntasks=1 --overlap in the wrapped `srun`, so that only one
     # task sleeps? Does that change anything?
+    # The wrapped script first dumps the job's SLURM env vars to a per-job file (used
+    # by VS Code terminals to recover the job's environment, since their SSH sessions
+    # are outside the job). `;` instead of `&&` so that a dump failure can't prevent
+    # the job from running.
+    wrap = f"{DUMP_COMMAND}; srun sleep 7d"
     sbatch_command = (
         "cd $SCRATCH && sbatch --parsable "
         + shlex.join(sbatch_flags)
-        + " --wrap 'srun sleep 7d'"
+        + " --wrap "
+        + shlex.quote(wrap)
     )
 
     job_id = None
@@ -370,6 +398,9 @@ async def sbatch(
         console.log(f"Received KeyboardInterrupt, cancelling job {job_id}")
         login_node.run(f"scancel {job_id}", display=True, hide=False)
         raise
+
+    # The batch script dumps the job's SLURM env vars right when it starts (see above).
+    await wait_for_env_file(login_node, job_id)
 
     return ComputeNode(job_id=job_id, login_node=login_node)
 

--- a/milatools/utils/slurm_env.py
+++ b/milatools/utils/slurm_env.py
@@ -1,0 +1,239 @@
+"""Forwards the SLURM allocation environment to VS Code terminals.
+
+VS Code's Remote-SSH extension connects to the compute node in a fresh SSH
+session, outside the salloc/srun job. `pam_slurm_adopt` adopts that session
+into the job's cgroup but only sets `SLURM_JOB_ID` — none of the other
+`SLURM_*` variables (`SLURM_NTASKS`, `SLURM_TASKS_PER_NODE`, `SLURM_TMPDIR`,
+...).
+
+To fix this, when `mila code` creates a job, the *allocation-level* SLURM
+environment (as seen by the salloc shell or the sbatch batch script — NOT the
+environment of a 1-task job step, which would have the wrong task geometry) is
+dumped to a per-job file on the shared filesystem. A guarded block installed
+in the user's shell rc file then sources that file in sessions that have
+`SLURM_JOB_ID` but not the rest of the job environment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.resources
+
+from milatools.cli import console
+from milatools.utils.remote_v2 import RemoteV2, logger
+
+_RESOURCES = importlib.resources.files("milatools.utils")
+
+# NOTE: A literal `$HOME` (expanded remotely) so that the dump script, the rc
+# hook and the commands below all compute the exact same path.
+SLURM_ENV_DIR = "$HOME/.cache/milatools/slurm_env"
+
+DUMP_SCRIPT_PATH = f"{SLURM_ENV_DIR}/dump.sh"
+
+
+def env_file_path(job_id: int) -> str:
+    """Path (on the cluster) of the env file for the given job."""
+    return f"{SLURM_ENV_DIR}/{job_id}.env"
+
+
+# Command used to run the dump script from within the job (from the salloc
+# shell's stdin or the sbatch --wrap script). Only uses syntax that is valid in
+# bash, zsh and fish, is silent, and is a no-op if the script was never
+# uploaded.
+DUMP_COMMAND = f'test -f "{DUMP_SCRIPT_PATH}" && sh "{DUMP_SCRIPT_PATH}"'
+
+# POSIX-sh script uploaded to DUMP_SCRIPT_PATH on the cluster.
+# It writes the SLURM_* variables of the current environment as safely-quoted
+# `export VAR='...'` lines to the per-job env file (allocation-level variables
+# only; see the comments in the script itself).
+DUMP_SCRIPT_CONTENT = (_RESOURCES / "slurm_env_dump.sh").read_text(encoding="utf-8")
+
+_RC_BLOCK_VERSION = 1
+RC_BLOCK_PREFIX = "# >>> milatools slurm-env"
+RC_BLOCK_START = f"{RC_BLOCK_PREFIX} v{_RC_BLOCK_VERSION} >>>"
+RC_BLOCK_END = "# <<< milatools slurm-env <<<"
+
+# Block installed in ~/.bashrc (and ~/.zshrc if it exists) on the cluster.
+# `_content_with_block_installed` replaces an installed block whenever its
+# content differs from the current RC_BLOCK, so any change to the .sh file (or
+# to `_RC_BLOCK_VERSION` above, kept as a human-readable marker of such
+# changes) gets rolled out to existing rc files.
+# Guards (all pure POSIX, valid in bash and zsh):
+# - `SLURM_JOB_ID`/`SLURM_JOBID` set: only sessions inside a job are affected
+#   (login nodes and regular SSH sessions are untouched);
+# - `SLURM_NTASKS` and `SLURM_STEP_ID` unset: real salloc/srun shells and the
+#   user's own job scripts already have the full environment and are never
+#   clobbered;
+# - the per-job env file exists: only jobs created by `mila code` have one.
+RC_BLOCK = (_RESOURCES / "slurm_env_rc_block.sh").read_text(encoding="utf-8")
+# NOTE: The file content already ends with a newline.
+RC_BLOCK = f"""{RC_BLOCK_START}
+{RC_BLOCK}{RC_BLOCK_END}
+"""
+
+
+def _content_with_block_installed(existing: str | None) -> str | None:
+    """Returns the new content of an rc file with the current RC_BLOCK installed.
+
+    Returns None if the file already contains the current version of the block.
+    An outdated block (different version between the same markers) is replaced
+    in place; otherwise the block is appended.
+    """
+    if existing is not None and RC_BLOCK.strip() in existing:
+        return None
+    if existing:
+        start = existing.find(RC_BLOCK_PREFIX)
+        if start != -1:
+            end = existing.find(RC_BLOCK_END, start)
+            if end != -1:
+                end += len(RC_BLOCK_END)
+                # Also consume the newline following the end marker, if any.
+                if existing[end : end + 1] == "\n":
+                    end += 1
+                return existing[:start] + RC_BLOCK + existing[end:]
+    if not existing:
+        return RC_BLOCK
+    if not existing.endswith("\n"):
+        existing += "\n"
+    return existing + "\n" + RC_BLOCK
+
+
+async def _install_block_in_rc_file(
+    login_node: RemoteV2, rc_file: str, only_if_exists: bool = False
+) -> None:
+    result = await login_node.run_async(
+        f"cat {rc_file}", display=False, warn=True, hide=True
+    )
+    if result.returncode not in (0, 1):
+        # Exit code 1 means the file doesn't exist; anything else (e.g. 255 for
+        # an SSH failure) means we can't know its content, and treating it as
+        # missing would overwrite the user's rc file with just the block.
+        logger.warning(
+            f"Could not read {rc_file} on {login_node.hostname} (exit code "
+            f"{result.returncode}); not installing the milatools block in it."
+        )
+        return
+    existing = result.stdout if result.returncode == 0 else None
+    if existing is None and only_if_exists:
+        return
+    new_content = _content_with_block_installed(existing)
+    if new_content is None:
+        logger.debug(f"The milatools block in {rc_file} is already up to date.")
+        return
+    console.log(
+        f"Adding a block to {rc_file} on {login_node.hostname} so that VS Code "
+        "terminals get the SLURM environment variables of the job.",
+        style="cyan",
+    )
+    await login_node.run_async(
+        f"cat > {rc_file}.milatools.tmp && mv {rc_file}.milatools.tmp {rc_file}",
+        input=new_content,
+        display=False,
+        hide=True,
+    )
+
+
+async def setup_slurm_env_hook(login_node: RemoteV2) -> None:
+    """Sets up what's needed for VS Code terminals to get the job's SLURM env.
+
+    - Uploads the env dump script (run from inside new jobs) to the cluster;
+    - Installs the rc block that sources the per-job env file in adopted
+      sessions into `~/.bashrc` (and `~/.zshrc`, only if it already exists);
+    - Prunes env files older than the maximum job duration.
+
+    Everything is best-effort: failures are logged as warnings and never
+    prevent `mila code` from working.
+    """
+    try:
+        existing_script = await login_node.run_async(
+            f'cat "{DUMP_SCRIPT_PATH}"', display=False, warn=True, hide=True
+        )
+        if existing_script.stdout != DUMP_SCRIPT_CONTENT:
+            logger.debug(f"Uploading the SLURM env dump script to {DUMP_SCRIPT_PATH}.")
+            await login_node.run_async(
+                f'mkdir -p "{SLURM_ENV_DIR}" && cat > "{DUMP_SCRIPT_PATH}"',
+                input=DUMP_SCRIPT_CONTENT,
+                display=False,
+                hide=True,
+            )
+
+        await _install_block_in_rc_file(login_node, "~/.bashrc")
+        await _install_block_in_rc_file(login_node, "~/.zshrc", only_if_exists=True)
+
+        # Prune env files of jobs that have necessarily ended (`mila code`
+        # jobs run for at most 7 days). Files of running jobs are removed in
+        # `ComputeNode.close`/`close_async` when the job is cancelled.
+        await login_node.run_async(
+            f'find "{SLURM_ENV_DIR}" -name "*.env" -mtime +8 -delete',
+            display=False,
+            warn=True,
+            hide=True,
+        )
+    except Exception as err:
+        logger.warning(
+            f"Unable to set up the SLURM env forwarding for VS Code terminals: {err}"
+        )
+
+
+async def wait_for_env_file(
+    login_node: RemoteV2, job_id: int, timeout: float = 15.0
+) -> bool:
+    """Waits until the env file for the given job exists on the cluster.
+
+    Returns False (after logging a warning) if the file doesn't show up within
+    `timeout` seconds.
+    """
+    try:
+        dump_script_exists = await login_node.run_async(
+            f'test -f "{DUMP_SCRIPT_PATH}"', display=False, warn=True, hide=True
+        )
+        if dump_script_exists.returncode != 0:
+            # `setup_slurm_env_hook` wasn't run (or failed): the job can't dump
+            # its env, no point in waiting for the file.
+            logger.debug(
+                "The SLURM env dump script isn't on the cluster; not waiting "
+                "for an env file."
+            )
+            return False
+        interval = 0.5
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while loop.time() < deadline:
+            result = await login_node.run_async(
+                f'test -f "{env_file_path(job_id)}"',
+                display=False,
+                warn=True,
+                hide=True,
+            )
+            if result.returncode == 0:
+                return True
+            await asyncio.sleep(interval)
+            interval = min(interval * 1.5, 2.0)
+    except Exception as err:
+        logger.warning(f"Error while waiting for the SLURM env file: {err}")
+        return False
+    logger.warning(
+        f"Timed out waiting for the SLURM env file of job {job_id}; VS Code "
+        "terminals may be missing some SLURM_* environment variables."
+    )
+    return False
+
+
+async def remove_env_file(login_node: RemoteV2, job_id: int) -> None:
+    """Removes the env file of the given job (best-effort)."""
+    try:
+        await login_node.run_async(
+            f'rm -f "{env_file_path(job_id)}"', display=False, warn=True, hide=True
+        )
+    except Exception as err:
+        logger.debug(f"Unable to remove the SLURM env file of job {job_id}: {err}")
+
+
+def remove_env_file_sync(login_node: RemoteV2, job_id: int) -> None:
+    """Synchronous version of `remove_env_file`."""
+    try:
+        login_node.run(
+            f'rm -f "{env_file_path(job_id)}"', display=False, warn=True, hide=True
+        )
+    except Exception as err:
+        logger.debug(f"Unable to remove the SLURM env file of job {job_id}: {err}")

--- a/milatools/utils/slurm_env.py
+++ b/milatools/utils/slurm_env.py
@@ -12,6 +12,11 @@ environment of a 1-task job step, which would have the wrong task geometry) is
 dumped to a per-job file on the shared filesystem. A guarded block installed
 in the user's shell rc file then sources that file in sessions that have
 `SLURM_JOB_ID` but not the rest of the job environment.
+
+In those sessions the block also wraps `sbatch` in a shell function that
+strips the restored variables for the submission only, so that jobs submitted
+from a VS Code terminal don't inherit the surrounding job's `SLURM_*` state
+(the classic nested-submission leak with sbatch's default `--export=ALL`).
 """
 
 from __future__ import annotations
@@ -65,6 +70,10 @@ RC_BLOCK_END = "# <<< milatools slurm-env <<<"
 #   user's own job scripts already have the full environment and are never
 #   clobbered;
 # - the per-job env file exists: only jobs created by `mila code` have one.
+# When the env file is sourced, the block also defines an `sbatch` wrapper
+# function that unsets the injected variables (in a subshell) before
+# submitting, so nested jobs get a clean environment; see the .sh file for the
+# bash/zsh portability constraints its exact form is built around.
 RC_BLOCK = (_RESOURCES / "slurm_env_rc_block.sh").read_text(encoding="utf-8")
 # NOTE: The file content already ends with a newline.
 RC_BLOCK = f"""{RC_BLOCK_START}

--- a/milatools/utils/slurm_env.py
+++ b/milatools/utils/slurm_env.py
@@ -53,7 +53,7 @@ DUMP_COMMAND = f'test -f "{DUMP_SCRIPT_PATH}" && sh "{DUMP_SCRIPT_PATH}"'
 # only; see the comments in the script itself).
 DUMP_SCRIPT_CONTENT = (_RESOURCES / "slurm_env_dump.sh").read_text(encoding="utf-8")
 
-_RC_BLOCK_VERSION = 1
+_RC_BLOCK_VERSION = 2
 RC_BLOCK_PREFIX = "# >>> milatools slurm-env"
 RC_BLOCK_START = f"{RC_BLOCK_PREFIX} v{_RC_BLOCK_VERSION} >>>"
 RC_BLOCK_END = "# <<< milatools slurm-env <<<"

--- a/milatools/utils/slurm_env_dump.sh
+++ b/milatools/utils/slurm_env_dump.sh
@@ -9,9 +9,13 @@
 # running this script, not the allocation, and sourcing them in a terminal
 # would break `srun` commands run from it (e.g. SLURM_NTASKS=1 instead of
 # the job's real task count).
-# SLURM_EXPORT_ENV is excluded because `sbatch`/`srun` honor it as their
-# `--export` default, which would silently change the behavior of commands
-# run from the terminal. SLURM_CONF is cluster configuration, not job state
+# SLURM_EXPORT_ENV, SLURM_CLUSTERS, SLURM_HINT, SLURM_DEBUG_FLAGS,
+# SLURM_EXIT_ERROR and SLURM_EXIT_IMMEDIATE are excluded because sbatch's
+# and/or salloc's own "Input Environment Variables" docs list them as
+# affecting those commands' behavior directly (aliases for --export,
+# --clusters, --hint, debug/exit-code tuning), not job state, so leaking
+# them into a terminal would silently change the behavior of sbatch/salloc/
+# srun run from it. SLURM_CONF is cluster configuration, not job state
 # (and must never be unset by the sbatch wrapper in the rc block).
 #
 # The sed pipeline turns `VAR=va'lue` into `export VAR='va'\''lue'`: values
@@ -27,6 +31,6 @@ file="$dir/$SLURM_JOB_ID.env"
 tmp="$file.tmp.$$"
 printenv \
   | grep '^SLURM_' \
-  | grep -Ev '^SLURM_(STEP|PROCID=|LOCALID=|NODEID=|GTIDS=|TASK_PID=|LAUNCH_NODE_IPADDR=|SRUN_COMM_|CPU_BIND|CPU_FREQ|DISTRIBUTION=|PTY_|TOPOLOGY_|UMASK=|EXPORT_ENV=|CONF=)' \
+  | grep -Ev '^SLURM_(STEP|PROCID=|LOCALID=|NODEID=|GTIDS=|TASK_PID=|LAUNCH_NODE_IPADDR=|SRUN_COMM_|CPU_BIND|CPU_FREQ|DISTRIBUTION=|PTY_|TOPOLOGY_|UMASK=|EXPORT_ENV=|CONF=|CLUSTERS=|HINT=|DEBUG_FLAGS=|EXIT_ERROR=|EXIT_IMMEDIATE=)' \
   | sed -e "s/'/'\\\\''/g" -e "s/=/='/" -e "s/\$/'/" -e 's/^/export /' \
   > "$tmp" && mv "$tmp" "$file"

--- a/milatools/utils/slurm_env_dump.sh
+++ b/milatools/utils/slurm_env_dump.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Managed by milatools (`mila code`) -- do not edit.
+# Dumps the SLURM allocation-level environment of the current job to a
+# per-job file, so that SSH sessions adopted into the job by pam_slurm_adopt
+# (e.g. VS Code Remote-SSH terminals) can restore it. See the milatools block
+# in ~/.bashrc.
+#
+# Step/task-specific variables are excluded: they describe the job step
+# running this script, not the allocation, and sourcing them in a terminal
+# would break `srun` commands run from it (e.g. SLURM_NTASKS=1 instead of
+# the job's real task count).
+#
+# The sed pipeline turns `VAR=va'lue` into `export VAR='va'\''lue'`: values
+# are single-quoted, with embedded single quotes escaped. (Limitation:
+# values containing newlines would break this line-based processing; no
+# SLURM variable contains newlines in practice.)
+set -u
+[ -n "${SLURM_JOB_ID:-}" ] || exit 0
+dir="$HOME/.cache/milatools/slurm_env"
+umask 077
+mkdir -p "$dir" || exit 0
+file="$dir/$SLURM_JOB_ID.env"
+tmp="$file.tmp.$$"
+printenv \
+  | grep '^SLURM_' \
+  | grep -Ev '^SLURM_(STEP|PROCID=|LOCALID=|NODEID=|GTIDS=|TASK_PID=|LAUNCH_NODE_IPADDR=|SRUN_COMM_|CPU_BIND|CPU_FREQ|DISTRIBUTION=|PTY_|TOPOLOGY_|UMASK=)' \
+  | sed -e "s/'/'\\\\''/g" -e "s/=/='/" -e "s/\$/'/" -e 's/^/export /' \
+  > "$tmp" && mv "$tmp" "$file"

--- a/milatools/utils/slurm_env_dump.sh
+++ b/milatools/utils/slurm_env_dump.sh
@@ -9,6 +9,10 @@
 # running this script, not the allocation, and sourcing them in a terminal
 # would break `srun` commands run from it (e.g. SLURM_NTASKS=1 instead of
 # the job's real task count).
+# SLURM_EXPORT_ENV is excluded because `sbatch`/`srun` honor it as their
+# `--export` default, which would silently change the behavior of commands
+# run from the terminal. SLURM_CONF is cluster configuration, not job state
+# (and must never be unset by the sbatch wrapper in the rc block).
 #
 # The sed pipeline turns `VAR=va'lue` into `export VAR='va'\''lue'`: values
 # are single-quoted, with embedded single quotes escaped. (Limitation:
@@ -23,6 +27,6 @@ file="$dir/$SLURM_JOB_ID.env"
 tmp="$file.tmp.$$"
 printenv \
   | grep '^SLURM_' \
-  | grep -Ev '^SLURM_(STEP|PROCID=|LOCALID=|NODEID=|GTIDS=|TASK_PID=|LAUNCH_NODE_IPADDR=|SRUN_COMM_|CPU_BIND|CPU_FREQ|DISTRIBUTION=|PTY_|TOPOLOGY_|UMASK=)' \
+  | grep -Ev '^SLURM_(STEP|PROCID=|LOCALID=|NODEID=|GTIDS=|TASK_PID=|LAUNCH_NODE_IPADDR=|SRUN_COMM_|CPU_BIND|CPU_FREQ|DISTRIBUTION=|PTY_|TOPOLOGY_|UMASK=|EXPORT_ENV=|CONF=)' \
   | sed -e "s/'/'\\\\''/g" -e "s/=/='/" -e "s/\$/'/" -e 's/^/export /' \
   > "$tmp" && mv "$tmp" "$file"

--- a/milatools/utils/slurm_env_rc_block.sh
+++ b/milatools/utils/slurm_env_rc_block.sh
@@ -7,6 +7,31 @@ if [ -n "${SLURM_JOB_ID:-}${SLURM_JOBID:-}" ] \
     _milatools_slurm_env="$HOME/.cache/milatools/slurm_env/${SLURM_JOB_ID:-${SLURM_JOBID:-}}.env"
     if [ -f "$_milatools_slurm_env" ]; then
         . "$_milatools_slurm_env"
+        # Names of the variables injected above (+ the job id, set by
+        # pam_slurm_adopt). Kept in a shell variable so the wrapper below
+        # keeps working after the env file is removed (job closed / pruned).
+        _milatools_slurm_env_vars="$(sed -n 's/^export \([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/p' "$_milatools_slurm_env" | tr '\n' ' ') SLURM_JOB_ID SLURM_JOBID"
+        # `sbatch` from this session submits with a clean environment (as from
+        # a login shell): with sbatch's default --export=ALL, the job's
+        # variables restored above would otherwise leak into the submitted
+        # job. `srun` is untouched: it needs them to run inside this job.
+        # Use `\sbatch` to bypass the wrapper.
+        # (`function` form: in zsh, a pre-existing `sbatch` alias would be a
+        # parse error in the POSIX `sbatch() {` form.)
+        function sbatch {
+            (
+                IFS=$' \t\n'
+                # ($(printf ...) instead of plain $var: zsh doesn't word-split
+                # parameter expansions, but does split command substitutions.)
+                for _v in $(printf '%s' "${_milatools_slurm_env_vars:-}"); do
+                    # Never unset cluster config (could come from an env file
+                    # dumped by an older milatools).
+                    case "$_v" in SLURM_CONF) continue ;; esac
+                    unset "$_v"
+                done
+                command sbatch "$@"
+            )
+        }
     fi
     unset _milatools_slurm_env
 fi

--- a/milatools/utils/slurm_env_rc_block.sh
+++ b/milatools/utils/slurm_env_rc_block.sh
@@ -1,0 +1,12 @@
+# Managed by milatools (`mila code`) -- do not edit this block.
+# In SSH sessions adopted into a SLURM job by pam_slurm_adopt (e.g. VS Code
+# Remote-SSH), only SLURM_JOB_ID is set. This restores the rest of the job's
+# allocation environment, dumped by milatools when the job was created.
+if [ -n "${SLURM_JOB_ID:-}${SLURM_JOBID:-}" ] \
+   && [ -z "${SLURM_NTASKS:-}" ] && [ -z "${SLURM_STEP_ID:-}" ]; then
+    _milatools_slurm_env="$HOME/.cache/milatools/slurm_env/${SLURM_JOB_ID:-${SLURM_JOBID:-}}.env"
+    if [ -f "$_milatools_slurm_env" ]; then
+        . "$_milatools_slurm_env"
+    fi
+    unset _milatools_slurm_env
+fi

--- a/tests/cli/test_code.py
+++ b/tests/cli/test_code.py
@@ -4,6 +4,8 @@ TODO: There are quite a few tests in `tests/integration/test_code.py` that could
 moved here, since some of them aren't exactly "integration" tests.
 """
 
+from __future__ import annotations
+
 from unittest.mock import AsyncMock, Mock
 
 import pytest

--- a/tests/cli/test_code.py
+++ b/tests/cli/test_code.py
@@ -12,6 +12,7 @@ import milatools.cli.code
 import milatools.cli.utils
 from milatools.utils.compute_node import ComputeNode
 from milatools.utils.local_v2 import LocalV2
+from milatools.utils.remote_v2 import RemoteV2
 
 
 @pytest.mark.parametrize("pretend_to_be_in_WSL", [True, False], indirect=True)
@@ -39,3 +40,82 @@ async def test_code_from_WSL(
         ),
         display=True,
     )
+
+
+@pytest.mark.parametrize(
+    ("job", "persist"),
+    [(None, False), (None, True), (123, True)],
+    ids=["salloc", "sbatch", "existing_job"],
+)
+@pytest.mark.asyncio
+async def test_setup_slurm_env_hook_called_only_when_creating_a_job(
+    monkeypatch: pytest.MonkeyPatch, job: int | None, persist: bool
+):
+    """The SLURM env forwarding is set up on the salloc/sbatch paths only.
+
+    The `--job`/`--node` path connects to an existing job, which milatools didn't
+    create and whose environment therefore wasn't dumped.
+    """
+    code_module = milatools.cli.code
+
+    mock_login_node = Mock(spec=RemoteV2, hostname="mila")
+    mock_login_node.configure_mock(
+        get_output_async=AsyncMock(
+            spec=RemoteV2.get_output_async, return_value="/home/mila/u/user"
+        ),
+    )
+    mock_remote_v2 = Mock(spec=RemoteV2)
+    mock_remote_v2.connect = AsyncMock(return_value=mock_login_node)
+    mock_compute_node = Mock(spec=ComputeNode, hostname="cn-a001", job_id=job or 456)
+
+    mock_compute_node_cls = Mock(spec=ComputeNode)
+    mock_compute_node_cls.connect = AsyncMock(return_value=mock_compute_node)
+
+    monkeypatch.setattr(
+        code_module, "shutil", Mock(which=Mock(return_value="/usr/bin/code"))
+    )
+    monkeypatch.setattr(code_module, RemoteV2.__name__, mock_remote_v2)
+    monkeypatch.setattr(code_module, "check_disk_quota", AsyncMock())
+    monkeypatch.setattr(code_module, "SSHConfig", Mock())
+    monkeypatch.setattr(code_module, "get_ssh_public_key_path", Mock(return_value=None))
+    monkeypatch.setattr(
+        code_module, "can_access_compute_nodes", Mock(return_value=True)
+    )
+    monkeypatch.setattr(
+        code_module, "internet_on_compute_nodes", Mock(return_value=True)
+    )
+    monkeypatch.setattr(
+        code_module, "salloc", mock_salloc := AsyncMock(return_value=mock_compute_node)
+    )
+    monkeypatch.setattr(
+        code_module, "sbatch", mock_sbatch := AsyncMock(return_value=mock_compute_node)
+    )
+    monkeypatch.setattr(code_module, ComputeNode.__name__, mock_compute_node_cls)
+    monkeypatch.setattr(code_module, "launch_vscode_loop", AsyncMock())
+    monkeypatch.setattr(
+        code_module, "setup_slurm_env_hook", mock_setup_hook := AsyncMock()
+    )
+
+    await code_module.code(
+        path="bob",
+        command="code",
+        persist=persist,
+        job=job,
+        node=None,
+        alloc=[],
+        cluster="mila",
+    )
+
+    if job is None:
+        mock_setup_hook.assert_awaited_once_with(mock_login_node)
+        if persist:
+            mock_sbatch.assert_awaited_once()
+            mock_salloc.assert_not_called()
+        else:
+            mock_salloc.assert_awaited_once()
+            mock_sbatch.assert_not_called()
+    else:
+        mock_setup_hook.assert_not_called()
+        mock_compute_node_cls.connect.assert_awaited_once()
+        mock_salloc.assert_not_called()
+        mock_sbatch.assert_not_called()

--- a/tests/utils/test_compute_node.py
+++ b/tests/utils/test_compute_node.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import logging
 import re
+import shlex
 import subprocess
 from logging import getLogger as get_logger
 from pathlib import Path
@@ -13,6 +14,7 @@ import pytest
 import pytest_asyncio
 
 import milatools.cli.utils
+import milatools.utils.compute_node
 from milatools.utils.compute_node import (
     ComputeNode,
     JobNotRunningError,
@@ -22,6 +24,11 @@ from milatools.utils.compute_node import (
     sbatch,
 )
 from milatools.utils.remote_v2 import RemoteV2
+from milatools.utils.slurm_env import (
+    DUMP_COMMAND,
+    env_file_path,
+    setup_slurm_env_hook,
+)
 
 from ..conftest import launches_jobs
 from .runner_tests import RunnerTests
@@ -31,6 +38,59 @@ logger = get_logger(__name__)
 pytestmark = [uses_remote_v2]
 
 
+@pytest_asyncio.fixture
+async def cluster_rc_files_backup(login_node_v2: RemoteV2):
+    """Snapshots ~/.bashrc and ~/.zshrc on the cluster and restores them after.
+
+    Used by tests that call `setup_slurm_env_hook`, which installs a block in
+    those files.
+    """
+    backups: dict[str, str | None] = {}
+    for rc_file in ("~/.bashrc", "~/.zshrc"):
+        result = await login_node_v2.run_async(
+            f"cat {rc_file}", display=False, warn=True, hide=True
+        )
+        backups[rc_file] = result.stdout if result.returncode == 0 else None
+    yield
+    for rc_file, content in backups.items():
+        if content is None:
+            await login_node_v2.run_async(
+                f"rm -f {rc_file}", display=False, warn=True, hide=True
+            )
+        else:
+            await login_node_v2.run_async(
+                f"cat > {rc_file}.milatools.bak && mv {rc_file}.milatools.bak {rc_file}",
+                input=content,
+                display=False,
+                warn=True,
+                hide=True,
+            )
+
+
+async def _check_env_file_lifecycle(login_node: RemoteV2, compute_node: ComputeNode):
+    """Checks that the job's env file exists with the allocation env vars in it, and
+    that it is removed when the job is closed."""
+    env_file = env_file_path(compute_node.job_id)
+    env_file_content = await login_node.get_output_async(
+        f'cat "{env_file}"', display=False, hide=True
+    )
+    assert f"export SLURM_JOB_ID='{compute_node.job_id}'" in env_file_content
+    assert "export SLURM_NTASKS=" in env_file_content
+    assert "export SLURM_TASKS_PER_NODE=" in env_file_content
+    # Step-specific variables must not be saved (they would break `srun` commands
+    # run from VS Code terminals that source this file).
+    assert "SLURM_STEP_ID" not in env_file_content
+    assert "SLURM_PROCID" not in env_file_content
+
+    await compute_node.close_async()
+
+    # The env file is removed when the job is closed.
+    result = await login_node.run_async(
+        f'test -f "{env_file}"', display=False, warn=True, hide=True
+    )
+    assert result.returncode != 0
+
+
 @launches_jobs
 @pytest.mark.slow
 @pytest.mark.asyncio
@@ -38,6 +98,7 @@ async def test_salloc(
     login_node_v2: RemoteV2,
     allocation_flags: list[str],
     job_name: str,
+    cluster_rc_files_backup: None,
 ):
     if login_node_v2.hostname == "localhost":
         # todo: Check why this (and other tests in this file) don't work on the mock
@@ -46,6 +107,7 @@ async def test_salloc(
         #   are actually running more than one job, so blocking each other?
         pytest.skip(reason="Test doesn't currently work on the mock slurm cluster.")
 
+    await setup_slurm_env_hook(login_node_v2)
     compute_node = await salloc(login_node_v2, allocation_flags, job_name=job_name)
 
     assert isinstance(compute_node, ComputeNode)
@@ -64,7 +126,8 @@ async def test_salloc(
     # using `srun` with the job id on the login node to run our jobs.
     assert all_slurm_env_vars["SLURM_JOB_ID"] == str(compute_node.job_id)
     assert len(all_slurm_env_vars) > 1
-    await compute_node.close_async()
+
+    await _check_env_file_lifecycle(login_node_v2, compute_node)
 
 
 @launches_jobs
@@ -74,10 +137,12 @@ async def test_sbatch(
     login_node_v2: RemoteV2,
     allocation_flags: list[str],
     job_name: str,
+    cluster_rc_files_backup: None,
 ):
     if login_node_v2.hostname == "localhost":
         pytest.skip(reason="Test doesn't currently work on the mock slurm cluster.")
 
+    await setup_slurm_env_hook(login_node_v2)
     compute_node = await sbatch(login_node_v2, allocation_flags, job_name=job_name)
     assert isinstance(compute_node, ComputeNode)
 
@@ -90,7 +155,49 @@ async def test_sbatch(
     }
     assert all_slurm_env_vars["SLURM_JOB_ID"] == str(compute_node.job_id)
     assert len(all_slurm_env_vars) > 1
-    await compute_node.close_async()
+
+    await _check_env_file_lifecycle(login_node_v2, compute_node)
+
+
+@pytest.mark.asyncio
+async def test_sbatch_wrap_script_dumps_the_slurm_env(monkeypatch: pytest.MonkeyPatch):
+    """The sbatch --wrap script dumps the job's SLURM env before sleeping."""
+    fake_job_id = 5678
+    sbatch_command: str | None = None
+
+    async def _mock_get_output_async(command: str, *args, **kwargs):
+        if command.startswith("squeue"):
+            # `cancel_new_jobs_on_interrupt` checking for existing jobs.
+            return ""
+        assert command.startswith("cd $SCRATCH && sbatch")
+        nonlocal sbatch_command
+        sbatch_command = command
+        return str(fake_job_id)
+
+    mock_login_node = Mock(spec=RemoteV2, hostname="mila")
+    mock_login_node.configure_mock(
+        get_output_async=AsyncMock(
+            spec=RemoteV2.get_output_async, side_effect=_mock_get_output_async
+        ),
+    )
+    monkeypatch.setattr(
+        milatools.utils.compute_node, "wait_while_job_is_pending", AsyncMock()
+    )
+    monkeypatch.setattr(
+        milatools.utils.compute_node, "wait_for_env_file", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(ComputeNode, "__post_init__", lambda self: None)
+
+    compute_node = await sbatch(
+        mock_login_node, sbatch_flags=["--time=01:00:00"], job_name="mila-code"
+    )
+
+    assert compute_node.job_id == fake_job_id
+    assert sbatch_command is not None
+    # The whole wrapped script is a single (properly quoted) argument, and the
+    # dump command can't prevent the job from running (`;`, not `&&`).
+    *_, wrap_script = shlex.split(sbatch_command)
+    assert wrap_script == f"{DUMP_COMMAND}; srun sleep 7d"
 
 
 @pytest.fixture(scope="session", params=[True, False], ids=["sbatch", "salloc"])
@@ -360,11 +467,15 @@ async def mock_closed_compute_node(
             return subprocess.CompletedProcess(command, 0, "cn-a001", "")
         if command == f"scancel {fake_job_id}":
             return subprocess.CompletedProcess(command, 0, "", "")
+        if command == f'rm -f "{env_file_path(fake_job_id)}"':
+            return subprocess.CompletedProcess(command, 0, "", "")
         # Unexpected command.
         assert False, (command, input)
 
     async def _mock_run_async(command: str, *args, input: str | None = None, **kwargs):
         if command == f"scancel {fake_job_id}":
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command == f'rm -f "{env_file_path(fake_job_id)}"':
             return subprocess.CompletedProcess(command, 0, "", "")
         # Unexpected command.
         assert False, (command, input)
@@ -387,14 +498,18 @@ async def mock_closed_compute_node(
 
     if close_async:
         await compute_node.close_async()
-        mock_run_async.assert_called_once()
+        # The job is cancelled and its SLURM env file is removed.
+        assert mock_run_async.call_count == 2
         assert mock_run_async.mock_calls[0].args[0] == f"scancel {fake_job_id}"
+        assert (
+            mock_run_async.mock_calls[1].args[0]
+            == f'rm -f "{env_file_path(fake_job_id)}"'
+        )
     else:
         compute_node.close()
-        # bug? this doesn't work but the output is identical?
-        # mock_run.assert_called_once_with(f"scancel {fake_job_id}")
-        mock_run.assert_called_once()
+        assert mock_run.call_count == 2
         assert mock_run.mock_calls[0].args[0] == f"scancel {fake_job_id}"
+        assert mock_run.mock_calls[1].args[0] == f'rm -f "{env_file_path(fake_job_id)}"'
     mock_run.reset_mock()
     mock_run_async.reset_mock()
     return compute_node

--- a/tests/utils/test_slurm_env.py
+++ b/tests/utils/test_slurm_env.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from pytest_regressions.file_regression import FileRegressionFixture
+
+from milatools.utils.remote_v2 import RemoteV2
+from milatools.utils.slurm_env import (
+    DUMP_SCRIPT_CONTENT,
+    DUMP_SCRIPT_PATH,
+    RC_BLOCK,
+    RC_BLOCK_END,
+    RC_BLOCK_START,
+    SLURM_ENV_DIR,
+    _content_with_block_installed,
+    env_file_path,
+    remove_env_file,
+    remove_env_file_sync,
+    setup_slurm_env_hook,
+    wait_for_env_file,
+)
+
+JOB_ID = 1234
+
+ALLOCATION_ENV = {
+    "SLURM_JOB_ID": str(JOB_ID),
+    "SLURM_NTASKS": "4",
+    "SLURM_NNODES": "2",
+    "SLURM_TASKS_PER_NODE": "3,1",
+    "SLURM_JOB_NODELIST": "cn-f[001-002]",
+    "SLURM_TMPDIR": f"/Tmp/slurm.{JOB_ID}.0",
+    # A value with spaces and single quotes, to test the quoting.
+    "SLURM_JOB_NAME": "it's a 'test' job",
+}
+STEP_ENV = {
+    "SLURM_STEP_ID": "0",
+    "SLURM_STEPID": "0",
+    "SLURM_PROCID": "0",
+    "SLURM_LOCALID": "0",
+    "SLURM_NODEID": "0",
+    "SLURM_GTIDS": "0",
+    "SLURM_TASK_PID": "12345",
+    "SLURM_LAUNCH_NODE_IPADDR": "10.0.0.1",
+    "SLURM_SRUN_COMM_HOST": "10.0.0.1",
+    "SLURM_CPU_BIND": "quiet,mask_cpu:0x3",
+    "SLURM_DISTRIBUTION": "cyclic",
+    "SLURM_PTY_PORT": "12346",
+    "SLURM_TOPOLOGY_ADDR": "cn-f001",
+    "SLURM_UMASK": "0022",
+    "SLURMD_NODENAME": "cn-f001",
+}
+
+
+def _run_dump_script(home: Path, env: dict[str, str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["sh", "-c", DUMP_SCRIPT_CONTENT],
+        env={"HOME": str(home), "PATH": os.environ["PATH"], **env},
+        capture_output=True,
+        text=True,
+    )
+
+
+def _local_env_file(home: Path, job_id: int = JOB_ID) -> Path:
+    return home / ".cache/milatools/slurm_env" / f"{job_id}.env"
+
+
+def test_dump_script_writes_the_allocation_env(tmp_path: Path):
+    result = _run_dump_script(tmp_path, {**ALLOCATION_ENV, **STEP_ENV})
+    assert result.returncode == 0, result.stderr
+
+    env_file = _local_env_file(tmp_path)
+    assert env_file.exists()
+
+    # Sourcing the file in a fresh shell reproduces the allocation env exactly
+    # (and nothing else).
+    sourced_env_lines = subprocess.run(
+        ["sh", "-c", f". '{env_file}'; printenv | grep '^SLURM'"],
+        env={"PATH": os.environ["PATH"]},
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    sourced_env = dict(line.split("=", maxsplit=1) for line in sourced_env_lines)
+    assert sourced_env == ALLOCATION_ENV
+
+
+def test_dump_script_does_nothing_outside_a_job(tmp_path: Path):
+    result = _run_dump_script(tmp_path, {})
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / ".cache").exists()
+
+
+shells = (
+    pytest.param("bash"),
+    pytest.param(
+        "zsh",
+        marks=pytest.mark.skipif(not shutil.which("zsh"), reason="zsh isn't installed"),
+    ),
+)
+
+
+@pytest.mark.parametrize("shell", shells)
+@pytest.mark.parametrize(
+    ("session_env", "expected_ntasks"),
+    [
+        # A pam_slurm_adopt-adopted session (e.g. VS Code terminal): only the
+        # job id is set -> the env file should be sourced.
+        ({"SLURM_JOB_ID": str(JOB_ID)}, "4"),
+        # Same, with the alternate spelling of the job id variable.
+        ({"SLURM_JOBID": str(JOB_ID)}, "4"),
+        # Login node / laptop: no SLURM vars at all -> inert.
+        ({}, "unset"),
+        # A real salloc/srun shell already has the full env -> never clobbered.
+        ({"SLURM_JOB_ID": str(JOB_ID), "SLURM_NTASKS": "1"}, "1"),
+        ({"SLURM_JOB_ID": str(JOB_ID), "SLURM_STEP_ID": "0"}, "unset"),
+        # A job that milatools didn't create: no env file -> inert.
+        ({"SLURM_JOB_ID": str(JOB_ID + 1)}, "unset"),
+    ],
+    ids=[
+        "adopted_session",
+        "adopted_session_alt_spelling",
+        "no_job",
+        "real_shell_with_ntasks",
+        "real_step_shell",
+        "foreign_job",
+    ],
+)
+def test_rc_block_guards(
+    tmp_path: Path, shell: str, session_env: dict[str, str], expected_ntasks: str
+):
+    # Create the env file for JOB_ID, as the dump script would.
+    result = _run_dump_script(tmp_path, ALLOCATION_ENV)
+    assert result.returncode == 0, result.stderr
+    rc_file = tmp_path / "rcfile"
+    rc_file.write_text(RC_BLOCK)
+
+    output = subprocess.run(
+        [shell, "-c", f". '{rc_file}'; echo \"${{SLURM_NTASKS:-unset}}\""],
+        env={"HOME": str(tmp_path), "PATH": os.environ["PATH"], **session_env},
+        capture_output=True,
+        text=True,
+    )
+    assert output.returncode == 0, output.stderr
+    assert output.stdout.strip() == expected_ntasks
+
+
+class TestContentWithBlockInstalled:
+    def test_missing_or_empty_file(self):
+        assert _content_with_block_installed(None) == RC_BLOCK
+        assert _content_with_block_installed("") == RC_BLOCK
+
+    def test_appends_to_existing_content(self):
+        existing = "# my stuff\nalias ll='ls -l'\n"
+        new_content = _content_with_block_installed(existing)
+        assert new_content is not None
+        assert new_content.startswith(existing)
+        assert new_content.endswith(RC_BLOCK)
+
+    def test_adds_missing_final_newline(self):
+        new_content = _content_with_block_installed("# no final newline")
+        assert new_content is not None
+        assert new_content.startswith("# no final newline\n")
+        assert new_content.endswith(RC_BLOCK)
+
+    def test_up_to_date_block_is_left_alone(self):
+        existing = "# my stuff\n\n" + RC_BLOCK
+        assert _content_with_block_installed(existing) is None
+
+    def test_outdated_block_is_replaced_in_place(
+        self, file_regression: FileRegressionFixture
+    ):
+        outdated_block = RC_BLOCK.replace("v1", "v0").replace(
+            "This restores", "(old text) This restores"
+        )
+        existing = f"# before the block\n\n{outdated_block}\n# after the block\n"
+        new_content = _content_with_block_installed(existing)
+        assert new_content is not None
+        assert new_content.startswith("# before the block\n")
+        assert new_content.endswith("# after the block\n")
+        assert RC_BLOCK in new_content
+        assert "v0" not in new_content
+        file_regression.check(new_content)
+
+    def test_result_is_idempotent(self):
+        new_content = _content_with_block_installed("# my stuff\n")
+        assert new_content is not None
+        assert _content_with_block_installed(new_content) is None
+
+
+class _FakeCluster:
+    """Backs a mocked RemoteV2 with a dict-based fake filesystem.
+
+    Understands only the commands issued by the functions under test.
+    """
+
+    def __init__(self) -> None:
+        self.files: dict[str, str] = {}
+        self.write_commands: list[str] = []
+
+    def run(self, command: str, *args, input: str | None = None, **kwargs):
+        if command.startswith("cat > "):
+            # `cat > {tmp} && mv {tmp} {file}` or `mkdir -p {dir} && cat > {file}`
+            assert input is not None
+            target = command.split()[-1]
+            self.files[target] = input
+            self.write_commands.append(command)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command.startswith("mkdir -p ") and "cat > " in command:
+            assert input is not None
+            target = command.split()[-1].strip('"')
+            self.files[target] = input
+            self.write_commands.append(command)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command.startswith("cat "):
+            path = command.removeprefix("cat ").strip('"')
+            if path in self.files:
+                return subprocess.CompletedProcess(command, 0, self.files[path], "")
+            return subprocess.CompletedProcess(command, 1, "", "No such file")
+        if command.startswith("find "):
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command.startswith("test -f "):
+            path = command.removeprefix("test -f ").strip('"')
+            returncode = 0 if path in self.files else 1
+            return subprocess.CompletedProcess(command, returncode, "", "")
+        if command.startswith("rm -f "):
+            path = command.removeprefix("rm -f ").strip('"')
+            self.files.pop(path, None)
+            self.write_commands.append(command)
+            return subprocess.CompletedProcess(command, 0, "", "")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    def mock_login_node(self) -> Mock:
+        async def _run_async(command: str, *args, **kwargs):
+            return self.run(command, *args, **kwargs)
+
+        mock_login_node = Mock(spec=RemoteV2, hostname="mila")
+        mock_login_node.configure_mock(
+            run=Mock(spec=RemoteV2.run, side_effect=self.run),
+            run_async=AsyncMock(spec=RemoteV2.run_async, side_effect=_run_async),
+        )
+        return mock_login_node
+
+
+@pytest.mark.asyncio
+async def test_setup_slurm_env_hook():
+    fake_cluster = _FakeCluster()
+    fake_cluster.files["~/.zshrc"] = "# my zsh stuff\n"
+    login_node = fake_cluster.mock_login_node()
+
+    await setup_slurm_env_hook(login_node)
+
+    assert fake_cluster.files[DUMP_SCRIPT_PATH] == DUMP_SCRIPT_CONTENT
+    # ~/.bashrc was created with the block, the pre-existing ~/.zshrc got it
+    # appended.
+    assert fake_cluster.files["~/.bashrc"] == RC_BLOCK
+    assert fake_cluster.files["~/.zshrc"].startswith("# my zsh stuff\n")
+    assert fake_cluster.files["~/.zshrc"].endswith(RC_BLOCK)
+
+
+@pytest.mark.asyncio
+async def test_setup_slurm_env_hook_does_not_create_zshrc():
+    fake_cluster = _FakeCluster()
+    await setup_slurm_env_hook(fake_cluster.mock_login_node())
+    assert "~/.zshrc" not in fake_cluster.files
+
+
+@pytest.mark.asyncio
+async def test_setup_slurm_env_hook_is_idempotent():
+    fake_cluster = _FakeCluster()
+    login_node = fake_cluster.mock_login_node()
+    await setup_slurm_env_hook(login_node)
+    files_after_first_call = dict(fake_cluster.files)
+    fake_cluster.write_commands.clear()
+
+    await setup_slurm_env_hook(login_node)
+
+    assert fake_cluster.write_commands == []
+    assert fake_cluster.files == files_after_first_call
+
+
+@pytest.mark.asyncio
+async def test_setup_slurm_env_hook_never_raises():
+    login_node = Mock(spec=RemoteV2, hostname="mila")
+    login_node.configure_mock(
+        run_async=AsyncMock(
+            spec=RemoteV2.run_async, side_effect=RuntimeError("connection lost")
+        ),
+    )
+    # Should log a warning, not raise.
+    await setup_slurm_env_hook(login_node)
+
+
+@pytest.mark.asyncio
+async def test_unreadable_rc_file_is_not_overwritten():
+    """An rc file that can't be read (e.g. exit code 255 on a transient SSH
+    failure) must not be treated as missing, which would overwrite it with just
+    the block."""
+    fake_cluster = _FakeCluster()
+    fake_cluster.files["~/.bashrc"] = "# my precious bashrc\n"
+    login_node = fake_cluster.mock_login_node()
+
+    async def _run_async(command: str, *args, **kwargs):
+        if command == "cat ~/.bashrc":
+            return subprocess.CompletedProcess(command, 255, "", "connection lost")
+        return fake_cluster.run(command, *args, **kwargs)
+
+    login_node.run_async.side_effect = _run_async
+
+    await setup_slurm_env_hook(login_node)
+
+    assert fake_cluster.files["~/.bashrc"] == "# my precious bashrc\n"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_env_file():
+    fake_cluster = _FakeCluster()
+    fake_cluster.files[DUMP_SCRIPT_PATH] = DUMP_SCRIPT_CONTENT
+    login_node = fake_cluster.mock_login_node()
+
+    assert not await wait_for_env_file(login_node, JOB_ID, timeout=1.0)
+
+    fake_cluster.files[env_file_path(JOB_ID)] = "export SLURM_NTASKS='4'\n"
+    assert await wait_for_env_file(login_node, JOB_ID, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_env_file_returns_early_without_the_dump_script():
+    """No need to wait for an env file if the dump script isn't on the cluster."""
+    fake_cluster = _FakeCluster()
+    fake_cluster.files[env_file_path(JOB_ID)] = "export SLURM_NTASKS='4'\n"
+    login_node = fake_cluster.mock_login_node()
+
+    assert not await wait_for_env_file(login_node, JOB_ID, timeout=30.0)
+    # Only the check for the dump script was made (no polling for the env file).
+    login_node.run_async.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_env_file_does_not_raise():
+    login_node = Mock(spec=RemoteV2, hostname="mila")
+    login_node.configure_mock(
+        run_async=AsyncMock(
+            spec=RemoteV2.run_async, side_effect=RuntimeError("connection lost")
+        ),
+    )
+    assert not await wait_for_env_file(login_node, JOB_ID, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_remove_env_file():
+    fake_cluster = _FakeCluster()
+    fake_cluster.files[env_file_path(JOB_ID)] = "export SLURM_NTASKS='4'\n"
+    login_node = fake_cluster.mock_login_node()
+
+    await remove_env_file(login_node, JOB_ID)
+    assert env_file_path(JOB_ID) not in fake_cluster.files
+
+    fake_cluster.files[env_file_path(JOB_ID)] = "export SLURM_NTASKS='4'\n"
+    remove_env_file_sync(login_node, JOB_ID)
+    assert env_file_path(JOB_ID) not in fake_cluster.files
+
+
+def test_sh_files_match_the_python_side_markers():
+    """The .sh files are loaded as package data; make sure their content stays
+    consistent with the constants used by the Python code to locate them."""
+    assert DUMP_SCRIPT_CONTENT.startswith("#!/bin/sh\n")
+    # `_content_with_block_installed` finds installed (possibly outdated)
+    # blocks with these markers.
+    assert RC_BLOCK.startswith(RC_BLOCK_START + "\n")
+    assert RC_BLOCK.endswith(RC_BLOCK_END + "\n")
+
+
+def test_paths_are_home_relative():
+    """The script, hook and Python code must all compute the same paths, so
+    they are all based on a literal `$HOME` (expanded on the cluster)."""
+    assert SLURM_ENV_DIR.startswith("$HOME/")
+    assert DUMP_SCRIPT_PATH.startswith(f"{SLURM_ENV_DIR}/")
+    assert env_file_path(JOB_ID) == f"{SLURM_ENV_DIR}/{JOB_ID}.env"
+    assert "$HOME/.cache/milatools/slurm_env" in RC_BLOCK
+    assert '"$HOME/.cache/milatools/slurm_env"' in DUMP_SCRIPT_CONTENT

--- a/tests/utils/test_slurm_env.py
+++ b/tests/utils/test_slurm_env.py
@@ -37,6 +37,13 @@ ALLOCATION_ENV = {
     # A value with spaces and single quotes, to test the quoting.
     "SLURM_JOB_NAME": "it's a 'test' job",
 }
+# Not step-specific, but still excluded from the dump: SLURM_EXPORT_ENV is
+# honored by sbatch/srun as their --export default, and SLURM_CONF is cluster
+# configuration, not job state.
+EXCLUDED_ENV = {
+    "SLURM_EXPORT_ENV": "ALL",
+    "SLURM_CONF": "/etc/slurm/slurm.conf",
+}
 STEP_ENV = {
     "SLURM_STEP_ID": "0",
     "SLURM_STEPID": "0",
@@ -70,7 +77,7 @@ def _local_env_file(home: Path, job_id: int = JOB_ID) -> Path:
 
 
 def test_dump_script_writes_the_allocation_env(tmp_path: Path):
-    result = _run_dump_script(tmp_path, {**ALLOCATION_ENV, **STEP_ENV})
+    result = _run_dump_script(tmp_path, {**ALLOCATION_ENV, **STEP_ENV, **EXCLUDED_ENV})
     assert result.returncode == 0, result.stderr
 
     env_file = _local_env_file(tmp_path)
@@ -146,6 +153,143 @@ def test_rc_block_guards(
     )
     assert output.returncode == 0, output.stderr
     assert output.stdout.strip() == expected_ntasks
+
+
+def _setup_terminal(tmp_path: Path, sbatch_exit_code: int = 0) -> Path:
+    """Sets up what an adopted VS Code terminal session needs: the per-job env
+    file (via the dump script), an rc file with the block, and a fake `sbatch`
+    on PATH that prints the SLURM_*/MY_VAR variables of its environment and
+    its arguments. Returns the fake bin directory."""
+    result = _run_dump_script(tmp_path, ALLOCATION_ENV)
+    assert result.returncode == 0, result.stderr
+    (tmp_path / "rcfile").write_text(RC_BLOCK)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_sbatch = bin_dir / "sbatch"
+    fake_sbatch.write_text(
+        "#!/bin/sh\n"
+        "printenv | grep -e '^SLURM_' -e '^MY_VAR'\n"
+        'echo "args: $@"\n'
+        f"exit {sbatch_exit_code}\n"
+    )
+    fake_sbatch.chmod(0o755)
+    return bin_dir
+
+
+def _run_terminal_command(
+    shell: str,
+    tmp_path: Path,
+    bin_dir: Path,
+    command: str,
+    session_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    if session_env is None:
+        session_env = {"SLURM_JOB_ID": str(JOB_ID)}
+    return subprocess.run(
+        [shell, "-c", f". '{tmp_path / 'rcfile'}'; {command}"],
+        env={
+            "HOME": str(tmp_path),
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            **session_env,
+        },
+        capture_output=True,
+        text=True,
+    )
+
+
+def _slurm_vars_in(output: str) -> list[str]:
+    return [line for line in output.splitlines() if line.startswith("SLURM_")]
+
+
+@pytest.mark.parametrize("shell", shells)
+def test_sbatch_wrapper_submits_with_a_clean_env(tmp_path: Path, shell: str):
+    """`sbatch` from an adopted session must not leak the restored job env into
+    the submitted job, while the user's own environment and arguments pass
+    through, and the terminal keeps the job env afterwards."""
+    bin_dir = _setup_terminal(tmp_path)
+    output = _run_terminal_command(
+        shell,
+        tmp_path,
+        bin_dir,
+        "export MY_VAR=hello; sbatch --ntasks=2 job.sh;"
+        ' echo "after: ${SLURM_NTASKS:-unset}"',
+    )
+    assert output.returncode == 0, output.stderr
+    assert _slurm_vars_in(output.stdout) == []
+    assert "MY_VAR=hello" in output.stdout
+    assert "args: --ntasks=2 job.sh" in output.stdout
+    # The wrapper's unsets are contained in a subshell: the terminal itself
+    # keeps the job's environment (needed by `srun`, user scripts, ...).
+    assert "after: 4" in output.stdout
+
+
+@pytest.mark.parametrize("shell", shells)
+def test_sbatch_wrapper_propagates_the_exit_code(tmp_path: Path, shell: str):
+    bin_dir = _setup_terminal(tmp_path, sbatch_exit_code=3)
+    output = _run_terminal_command(shell, tmp_path, bin_dir, "sbatch job.sh")
+    assert output.returncode == 3, output.stderr
+
+
+@pytest.mark.parametrize("shell", shells)
+def test_sbatch_wrapper_with_hostile_ifs(tmp_path: Path, shell: str):
+    """A custom IFS in the terminal must not defeat the cleanup (word
+    splitting of the variable-name list depends on IFS)."""
+    bin_dir = _setup_terminal(tmp_path)
+    output = _run_terminal_command(shell, tmp_path, bin_dir, "IFS=:; sbatch job.sh")
+    assert output.returncode == 0, output.stderr
+    assert _slurm_vars_in(output.stdout) == []
+
+
+@pytest.mark.parametrize("shell", shells)
+def test_sbatch_wrapper_under_set_u(tmp_path: Path, shell: str):
+    bin_dir = _setup_terminal(tmp_path)
+    output = _run_terminal_command(shell, tmp_path, bin_dir, "set -u; sbatch job.sh")
+    assert output.returncode == 0, output.stderr
+    assert _slurm_vars_in(output.stdout) == []
+
+
+@pytest.mark.parametrize("shell", shells)
+def test_sbatch_wrapper_preserves_slurm_conf(tmp_path: Path, shell: str):
+    """Env files dumped by older milatools versions may contain SLURM_CONF
+    (cluster configuration): the wrapper must never unset it, or sbatch
+    couldn't find the cluster config at all."""
+    bin_dir = _setup_terminal(tmp_path)
+    with _local_env_file(tmp_path).open("a") as f:
+        f.write("export SLURM_CONF='/etc/slurm/slurm.conf'\n")
+    output = _run_terminal_command(shell, tmp_path, bin_dir, "sbatch job.sh")
+    assert output.returncode == 0, output.stderr
+    assert _slurm_vars_in(output.stdout) == ["SLURM_CONF=/etc/slurm/slurm.conf"]
+
+
+@pytest.mark.parametrize("shell", shells)
+def test_rc_block_parses_with_a_preexisting_sbatch_alias(tmp_path: Path, shell: str):
+    """A user-defined `sbatch` alias earlier in the rc file must not break
+    sourcing the block (in zsh, aliases expand while *parsing* a function
+    definition, so the POSIX `sbatch() {...}` form would be a parse error that
+    aborts the rest of the rc file)."""
+    bin_dir = _setup_terminal(tmp_path)
+    rc_file = tmp_path / "rcfile"
+    rc_file.write_text("alias sbatch='sbatch --partition=main'\n" + RC_BLOCK)
+    output = _run_terminal_command(shell, tmp_path, bin_dir, "echo sourced-ok")
+    assert output.returncode == 0, output.stderr
+    assert "sourced-ok" in output.stdout
+    assert "parse error" not in output.stderr
+
+
+@pytest.mark.parametrize("shell", shells)
+def test_sbatch_is_not_wrapped_in_real_job_shells(tmp_path: Path, shell: str):
+    """In a real salloc/srun shell the block never sources the env file, so
+    `sbatch` must behave exactly as it normally does there (env untouched)."""
+    bin_dir = _setup_terminal(tmp_path)
+    output = _run_terminal_command(
+        shell,
+        tmp_path,
+        bin_dir,
+        "sbatch job.sh",
+        session_env={"SLURM_JOB_ID": str(JOB_ID), "SLURM_NTASKS": "1"},
+    )
+    assert output.returncode == 0, output.stderr
+    assert "SLURM_NTASKS=1" in output.stdout
 
 
 class TestContentWithBlockInstalled:

--- a/tests/utils/test_slurm_env.py
+++ b/tests/utils/test_slurm_env.py
@@ -37,12 +37,20 @@ ALLOCATION_ENV = {
     # A value with spaces and single quotes, to test the quoting.
     "SLURM_JOB_NAME": "it's a 'test' job",
 }
-# Not step-specific, but still excluded from the dump: SLURM_EXPORT_ENV is
-# honored by sbatch/srun as their --export default, and SLURM_CONF is cluster
-# configuration, not job state.
+# Not step-specific, but still excluded from the dump: these are documented
+# `sbatch`/`salloc` "Input Environment Variables" (see
+# https://slurm.schedmd.com/sbatch.html#SECTION_INPUT-ENVIRONMENT-VARIABLES
+# and https://slurm.schedmd.com/salloc.html#SECTION_INPUT-ENVIRONMENT-VARIABLES),
+# not job state, and would silently change the behavior of sbatch/salloc/srun
+# run from the terminal if they leaked into it.
 EXCLUDED_ENV = {
     "SLURM_EXPORT_ENV": "ALL",
     "SLURM_CONF": "/etc/slurm/slurm.conf",
+    "SLURM_CLUSTERS": "some-other-cluster",
+    "SLURM_HINT": "compute_bound",
+    "SLURM_DEBUG_FLAGS": "Steps",
+    "SLURM_EXIT_ERROR": "63",
+    "SLURM_EXIT_IMMEDIATE": "64",
 }
 STEP_ENV = {
     "SLURM_STEP_ID": "0",
@@ -317,7 +325,7 @@ class TestContentWithBlockInstalled:
     def test_outdated_block_is_replaced_in_place(
         self, file_regression: FileRegressionFixture
     ):
-        outdated_block = RC_BLOCK.replace("v1", "v0").replace(
+        outdated_block = RC_BLOCK.replace("v2", "v1").replace(
             "This restores", "(old text) This restores"
         )
         existing = f"# before the block\n\n{outdated_block}\n# after the block\n"
@@ -326,7 +334,7 @@ class TestContentWithBlockInstalled:
         assert new_content.startswith("# before the block\n")
         assert new_content.endswith("# after the block\n")
         assert RC_BLOCK in new_content
-        assert "v0" not in new_content
+        assert "v1" not in new_content
         file_regression.check(new_content)
 
     def test_result_is_idempotent(self):

--- a/tests/utils/test_slurm_env/test_outdated_block_is_replaced_in_place.txt
+++ b/tests/utils/test_slurm_env/test_outdated_block_is_replaced_in_place.txt
@@ -1,6 +1,6 @@
 # before the block
 
-# >>> milatools slurm-env v1 >>>
+# >>> milatools slurm-env v2 >>>
 # Managed by milatools (`mila code`) -- do not edit this block.
 # In SSH sessions adopted into a SLURM job by pam_slurm_adopt (e.g. VS Code
 # Remote-SSH), only SLURM_JOB_ID is set. This restores the rest of the job's

--- a/tests/utils/test_slurm_env/test_outdated_block_is_replaced_in_place.txt
+++ b/tests/utils/test_slurm_env/test_outdated_block_is_replaced_in_place.txt
@@ -1,0 +1,18 @@
+# before the block
+
+# >>> milatools slurm-env v1 >>>
+# Managed by milatools (`mila code`) -- do not edit this block.
+# In SSH sessions adopted into a SLURM job by pam_slurm_adopt (e.g. VS Code
+# Remote-SSH), only SLURM_JOB_ID is set. This restores the rest of the job's
+# allocation environment, dumped by milatools when the job was created.
+if [ -n "${SLURM_JOB_ID:-}${SLURM_JOBID:-}" ] \
+   && [ -z "${SLURM_NTASKS:-}" ] && [ -z "${SLURM_STEP_ID:-}" ]; then
+    _milatools_slurm_env="$HOME/.cache/milatools/slurm_env/${SLURM_JOB_ID:-${SLURM_JOBID:-}}.env"
+    if [ -f "$_milatools_slurm_env" ]; then
+        . "$_milatools_slurm_env"
+    fi
+    unset _milatools_slurm_env
+fi
+# <<< milatools slurm-env <<<
+
+# after the block

--- a/tests/utils/test_slurm_env/test_outdated_block_is_replaced_in_place.txt
+++ b/tests/utils/test_slurm_env/test_outdated_block_is_replaced_in_place.txt
@@ -10,6 +10,31 @@ if [ -n "${SLURM_JOB_ID:-}${SLURM_JOBID:-}" ] \
     _milatools_slurm_env="$HOME/.cache/milatools/slurm_env/${SLURM_JOB_ID:-${SLURM_JOBID:-}}.env"
     if [ -f "$_milatools_slurm_env" ]; then
         . "$_milatools_slurm_env"
+        # Names of the variables injected above (+ the job id, set by
+        # pam_slurm_adopt). Kept in a shell variable so the wrapper below
+        # keeps working after the env file is removed (job closed / pruned).
+        _milatools_slurm_env_vars="$(sed -n 's/^export \([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/p' "$_milatools_slurm_env" | tr '\n' ' ') SLURM_JOB_ID SLURM_JOBID"
+        # `sbatch` from this session submits with a clean environment (as from
+        # a login shell): with sbatch's default --export=ALL, the job's
+        # variables restored above would otherwise leak into the submitted
+        # job. `srun` is untouched: it needs them to run inside this job.
+        # Use `\sbatch` to bypass the wrapper.
+        # (`function` form: in zsh, a pre-existing `sbatch` alias would be a
+        # parse error in the POSIX `sbatch() {` form.)
+        function sbatch {
+            (
+                IFS=$' \t\n'
+                # ($(printf ...) instead of plain $var: zsh doesn't word-split
+                # parameter expansions, but does split command substitutions.)
+                for _v in $(printf '%s' "${_milatools_slurm_env_vars:-}"); do
+                    # Never unset cluster config (could come from an env file
+                    # dumped by an older milatools).
+                    case "$_v" in SLURM_CONF) continue ;; esac
+                    unset "$_v"
+                done
+                command sbatch "$@"
+            )
+        }
     fi
     unset _milatools_slurm_env
 fi


### PR DESCRIPTION
## Summary
VS Code's Remote-SSH connects to the compute node outside the SLURM job, so its terminals only ever saw `SLURM_JOB_ID` and none of the other job variables (`SLURM_NTASKS`, `SLURM_TMPDIR`, etc.). This PR makes `mila code` dump the job's SLURM environment on the cluster and restore it in adopted terminal sessions, while keeping `sbatch` submissions from those terminals clean.

## Changes
- New `milatools/utils/slurm_env.py`: uploads a dump script and installs a guarded block in `~/.bashrc`/`~/.zshrc` that sources the job's saved env only in sessions that have `SLURM_JOB_ID` but not the rest of the job environment; also wraps `sbatch` to strip the restored variables from submissions so nested jobs don't inherit the terminal's job state (`\sbatch` bypasses the wrapper).
- New `milatools/utils/slurm_env_dump.sh`: POSIX script that dumps allocation-level `SLURM_*` variables (excluding step/task-specific and export/config vars) to a per-job file under `~/.cache/milatools/slurm_env/`.
- New `milatools/utils/slurm_env_rc_block.sh`: the rc block installed on the cluster, with careful POSIX/bash/zsh portability handling (alias-safe function definition, IFS-safe word splitting, `set -u` safety).
- `milatools/cli/code.py`: calls `setup_slurm_env_hook` before creating a job (only on the `salloc`/`sbatch` paths, not when attaching to an existing `--job`/`--node`).
- `milatools/utils/compute_node.py`: `salloc` and `sbatch` trigger the dump right after the job starts and wait for the env file to appear; `ComputeNode.close`/`close_async` remove the per-job env file on job teardown; `setup_slurm_env_hook` also prunes stale env files older than the max job duration.
- README: documents the feature, `sbatch` semantics, and known limitations (fish shells, nested shells, existing `sbatch` aliases, jobs not created by `mila code`).
- Extensive new tests in `tests/utils/test_slurm_env.py` (dump script behavior, rc block guards across bash/zsh, sbatch wrapper edge cases, rc-file install/idempotency/versioning) and updates to `tests/cli/test_code.py` / `tests/utils/test_compute_node.py` covering the hook's call sites and env-file lifecycle.

## Notes
- Everything is best-effort: failures to set up or dump the env are logged as warnings and never block `mila code`.
- Known limitations are called out in the README: no support for fish shells, only the `mila code`-created job path forwards its environment, and the `sbatch` wrapper doesn't apply in nested shells/scripts or if the user defines their own `sbatch` alias.